### PR TITLE
[Draft] Adding the concept of context

### DIFF
--- a/CBot/CMakeLists.txt
+++ b/CBot/CMakeLists.txt
@@ -163,6 +163,11 @@ target_sources(CBot PRIVATE
     src/CBot/CBotVar/CBotVarShort.h
     src/CBot/CBotVar/CBotVarString.cpp
     src/CBot/CBotVar/CBotVarString.h
+    src/CBot/context/cbot_context.cpp
+    src/CBot/context/cbot_context.h
+    src/CBot/context/cbot_user_pointer.h
+    src/CBot/context/context_observer.h
+    src/CBot/context/context_owner.h
     src/CBot/stdlib/Compilation.cpp
     src/CBot/stdlib/Compilation.h
     src/CBot/stdlib/FileFunctions.cpp

--- a/CBot/CMakeLists.txt
+++ b/CBot/CMakeLists.txt
@@ -170,6 +170,7 @@ target_sources(CBot PRIVATE
     src/CBot/context/cbot_user_pointer.h
     src/CBot/context/context_observer.h
     src/CBot/context/context_owner.h
+    src/CBot/context/external_call_list_interface.h
     src/CBot/context/list_constant.cpp
     src/CBot/context/list_constant.h
     src/CBot/context/list_constant_interface.h

--- a/CBot/CMakeLists.txt
+++ b/CBot/CMakeLists.txt
@@ -59,6 +59,8 @@ target_sources(CBot PRIVATE
     src/CBot/CBotInstr/CBotDo.h
     src/CBot/CBotInstr/CBotEmpty.cpp
     src/CBot/CBotInstr/CBotEmpty.h
+    src/CBot/CBotInstr/CBotExprConstant.cpp
+    src/CBot/CBotInstr/CBotExprConstant.h
     src/CBot/CBotInstr/CBotExprLitBool.cpp
     src/CBot/CBotInstr/CBotExprLitBool.h
     src/CBot/CBotInstr/CBotExprLitChar.cpp
@@ -168,6 +170,9 @@ target_sources(CBot PRIVATE
     src/CBot/context/cbot_user_pointer.h
     src/CBot/context/context_observer.h
     src/CBot/context/context_owner.h
+    src/CBot/context/list_constant.cpp
+    src/CBot/context/list_constant.h
+    src/CBot/context/list_constant_interface.h
     src/CBot/stdlib/Compilation.cpp
     src/CBot/stdlib/Compilation.h
     src/CBot/stdlib/FileFunctions.cpp

--- a/CBot/src/CBot/CBotCStack.cpp
+++ b/CBot/src/CBot/CBotCStack.cpp
@@ -21,8 +21,8 @@
 #include "CBot/CBotCStack.h"
 
 #include "CBot/CBotClass.h"
+#include "CBot/CBotProgram.h"
 #include "CBot/CBotToken.h"
-#include "CBot/CBotExternalCall.h"
 
 #include "CBot/CBotVar/CBotVar.h"
 
@@ -430,6 +430,11 @@ bool CBotCStack::CheckCall(CBotToken* &pToken, CBotDefParam* pParam, const std::
     }
 
     return false;
+}
+
+CBotClass* CBotCStack::FindClass(const std::string& name) const
+{
+    return GetContext()->FindClass(name);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotCStack.cpp
+++ b/CBot/src/CBot/CBotCStack.cpp
@@ -40,7 +40,14 @@ struct CBotCStack::Data
     int           errEnd = 0;
     //! The return type of the function currently being compiled
     CBotTypResult retTyp = CBotTypResult(CBotTypVoid);
+
+    CBotContext* context = nullptr;
 };
+
+CBotContext* CBotCStack::GetContext() const
+{
+    return m_data->context;
+}
 
 CBotCStack::CBotCStack(CBotCStack* ppapa)
 {
@@ -250,6 +257,7 @@ bool CBotCStack::NextToken(CBotToken* &p)
 void CBotCStack::SetProgram(CBotProgram* p)
 {
     m_data->prog = p;
+    m_data->context = p->GetContext().get();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/CBot/src/CBot/CBotCStack.cpp
+++ b/CBot/src/CBot/CBotCStack.cpp
@@ -28,6 +28,8 @@
 
 #include "CBot/CBotInstr/CBotFunction.h"
 
+#include "CBot/context/cbot_context.h"
+
 namespace CBot
 {
 
@@ -379,7 +381,7 @@ CBotTypResult CBotCStack::CompileCall(CBotToken* &p, CBotVar** ppVars, long& nId
     nIdent = 0;
     CBotTypResult val(-1);
 
-    val = GetProgram()->GetExternalCalls()->CompileCall(p, nullptr, ppVars, this);
+    val = GetContext()->CompileCall(p, nullptr, ppVars, this);
     if (val.GetType() < 0)
     {
         val = CBotFunction::CompileCall(p->GetString(), ppVars, nIdent, GetProgram());
@@ -399,7 +401,7 @@ bool CBotCStack::CheckCall(CBotToken* &pToken, CBotDefParam* pParam, const std::
 {
     const auto& name = pToken->GetString();
 
-    if ( GetProgram()->GetExternalCalls()->CheckCall(name) ) return true;
+    if ( GetContext()->CheckCall(name) ) return true;
 
     for (CBotFunction* pp : GetProgram()->GetFunctions())
     {

--- a/CBot/src/CBot/CBotCStack.cpp
+++ b/CBot/src/CBot/CBotCStack.cpp
@@ -416,7 +416,7 @@ bool CBotCStack::CheckCall(CBotToken* &pToken, CBotDefParam* pParam, const std::
         }
     }
 
-    for (CBotFunction* pp : CBotFunction::m_publicFunctions)
+    for (CBotFunction* pp : GetContext()->GetPublicFunctions())
     {
         if ( name == pp->GetName() )
         {

--- a/CBot/src/CBot/CBotCStack.h
+++ b/CBot/src/CBot/CBotCStack.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "CBot/CBotVar/CBotVar.h"
-#include "CBot/CBotProgram.h"
 
 #include <list>
 #include <memory>
@@ -28,9 +27,12 @@
 namespace CBot
 {
 
+class CBotClass;
 class CBotContext;
-class CBotInstr;
 class CBotDefParam;
+class CBotFunction;
+class CBotInstr;
+class CBotProgram;
 class CBotToken;
 
 /*!
@@ -278,6 +280,8 @@ public:
      * \return
      */
     bool NextToken(CBotToken* &p);
+
+    CBotClass* FindClass(const std::string& name) const;
 
 private:
     std::unique_ptr<CBotCStack> m_next;

--- a/CBot/src/CBot/CBotCStack.h
+++ b/CBot/src/CBot/CBotCStack.h
@@ -28,6 +28,7 @@
 namespace CBot
 {
 
+class CBotContext;
 class CBotInstr;
 class CBotDefParam;
 class CBotToken;
@@ -250,6 +251,8 @@ public:
      * \return
      */
     CBotProgram* GetProgram();
+
+    CBotContext* GetContext() const;
 
     /*!
      * \brief CompileCall

--- a/CBot/src/CBot/CBotClass.cpp
+++ b/CBot/src/CBot/CBotClass.cpp
@@ -37,6 +37,8 @@
 #include "CBot/CBotDefParam.h"
 #include "CBot/CBotUtils.h"
 
+#include "CBot/context/cbot_context.h"
+
 #include <algorithm>
 
 namespace CBot
@@ -289,7 +291,7 @@ bool CBotClass::AddFunction(const std::string& name,
                             bool rExec(CBotVar* pThis, CBotVar* pVar, CBotVar* pResult, int& Exception, void* user),
                             CBotTypResult rCompile(CBotVar* pThis, CBotVar*& pVar))
 {
-    return m_externalMethods->AddFunction(name, std::unique_ptr<CBotExternalCall>(new CBotExternalCallClass(rExec, rCompile)));
+    return m_externalMethods->AddFunction(name, rExec, rCompile);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -443,7 +445,7 @@ bool CBotClass::CheckCall(CBotProgram* program, CBotDefParam* pParam, CBotToken*
 {
     std::string  name = pToken->GetString();
 
-    if ( program->GetExternalCalls()->CheckCall(name) ) return true;
+    if ( program->GetContext()->CheckCall(name) ) return true;
 
     for (CBotFunction* pp : m_pMethod)
     {

--- a/CBot/src/CBot/CBotClass.cpp
+++ b/CBot/src/CBot/CBotClass.cpp
@@ -47,7 +47,9 @@ namespace CBot
 
 CBotClass::CBotClass(const std::string& name,
                      CBotClass* parent,
-                     bool bIntrinsic)
+                     const CBotContextSPtr& context,
+                     bool bIntrinsic) :
+    CBotContextObserver(context)
 {
     m_parent    = parent;
     m_name      = name;
@@ -71,9 +73,10 @@ CBotClass::~CBotClass()
 ////////////////////////////////////////////////////////////////////////////////
 CBotClass* CBotClass::Create(const std::string& name,
                              CBotClass* parent,
+                             const CBotContextSPtr& context,
                              bool intrinsic)
 {
-    return new CBotClass(name, parent, intrinsic);
+    return new CBotClass(name, parent, context, intrinsic);
 }
 
 void CBotClass::Purge()

--- a/CBot/src/CBot/CBotClass.h
+++ b/CBot/src/CBot/CBotClass.h
@@ -23,15 +23,16 @@
 #include "CBot/CBotTypResult.h"
 #include "CBot/CBotVar/CBotVar.h"
 
-#include <string>
+#include "CBot/context/context_observer.h"
+
 #include <deque>
-#include <set>
 #include <list>
+#include <set>
+#include <string>
 
 namespace CBot
 {
 
-class CBotCallMethode;
 class CBotFunction;
 class CBotProgram;
 class CBotStack;
@@ -104,7 +105,7 @@ class CBotExternalCallList;
  *  float y = var->GetValFloat();
  *  \endcode
  */
-class CBotClass
+class CBotClass : public CBotContextObserver
 {
 public:
     /*!
@@ -341,14 +342,14 @@ public:
      * \param ostr Output stream
      * \return true on success
      */
-    static bool SaveStaticState(std::ostream &ostr);
+    static bool SaveStaticState(std::ostream &ostr, CBotContext& context);
 
     /*!
      * \brief Restore all static variables in each public class
      * \param istr Input stream
      * \return true on success
      */
-    static bool RestoreStaticState(std::istream &istr);
+    static bool RestoreStaticState(std::istream &istr, CBotContext& context);
 
     /**
      * \brief Request a lock on this class (for "synchronized" keyword)

--- a/CBot/src/CBot/CBotClass.h
+++ b/CBot/src/CBot/CBotClass.h
@@ -120,6 +120,7 @@ private:
      */
     CBotClass(const std::string& name,
               CBotClass* parent,
+              const CBotContextSPtr& context,
               bool bIntrinsic = false);
 
 public:
@@ -137,11 +138,11 @@ public:
      */
     static CBotClass* Create(const std::string& name,
                              CBotClass* parent,
+                             const CBotContextSPtr& context,
                              bool intrinsic = false);
 
     /*!
      * \brief Add a function that can be called from CBot
-     * \see CBotProgram::AddFunction
      */
     bool AddFunction(const std::string& name,
                      ClassRuntimeFunc rExec,

--- a/CBot/src/CBot/CBotDefines.h
+++ b/CBot/src/CBot/CBotDefines.h
@@ -26,9 +26,3 @@
 
 //! Define the current CBot version
 #define    CBOTVERSION    104
-
-// for SetUserPtr when deleting an object
-// \TODO define own types to distinct between different states of objects
-#define OBJECTDELETED (reinterpret_cast<void*>(-1))
-// value set before initialization
-#define OBJECTCREATED (reinterpret_cast<void*>(-2))

--- a/CBot/src/CBot/CBotFileUtils.cpp
+++ b/CBot/src/CBot/CBotFileUtils.cpp
@@ -383,46 +383,6 @@ bool ReadStream(std::istream& istr, std::ostream &ostr)
     return true;
 }
 
-bool WriteVarList(std::ostream &ostr, CBotVar* pVar, CBotContext& context)
-{
-    while (pVar != nullptr)
-    {
-        if (!pVar->Save0State(ostr)) return false; // common header
-        if (!pVar->Save1State(ostr, context)) return false; // saves the data
-
-        pVar = pVar->GetNext();
-    }
-    return WriteWord(ostr, 0); // 0 - CBot::WriteVarList terminator
-}
-
-bool ReadVarList(std::istream &istr, CBotVar* &pVar, CBotContext& context)
-{
-    delete pVar;
-    pVar = nullptr;
-    CBotVar* pPrev = nullptr;
-    CBotVarUPtr outVar{nullptr};
-
-    while ( true )
-    {
-        CBotVarUPtr pNew{nullptr};
-        if (!CBotVar::RestoreVar(istr, pNew, context)) return false;
-
-        if ( !pNew ) break;             // 0 - CBot::WriteVarList terminator
-
-        if ( pPrev != nullptr )         // follow the end of the list
-        {
-            pPrev->AddNext(pNew.release());
-            pPrev = pPrev->GetNext();
-        }
-        else                            // set return param
-        {
-            outVar.reset(pPrev = pNew.release());
-        }
-    }
-    pVar = outVar.release();
-    return true;
-}
-
 bool WriteVarListAsArray(std::ostream &ostr, CBotVar* pVar, CBotContext& context)
 {
     std::size_t numVar{0};

--- a/CBot/src/CBot/CBotFileUtils.cpp
+++ b/CBot/src/CBot/CBotFileUtils.cpp
@@ -22,6 +22,8 @@
 #include "CBot/CBotClass.h"
 #include "CBot/CBotEnums.h"
 
+#include "CBot/context/cbot_context.h"
+
 namespace CBot
 {
 
@@ -320,9 +322,12 @@ bool ReadType(std::istream &istr, CBotTypResult &type, CBotContext& context)
 
     if ( type.Eq( CBotTypClass ) )
     {
-        std::string  s;
-        if (!ReadString(istr, s)) return false;
-        type = CBotTypResult( w, s );
+        std::string className;
+        if (!ReadString(istr, className)) return false;
+        if (className.empty()) { assert(false); return false; }
+        auto pClass = context.FindClass(className);
+        if (pClass == nullptr) { assert(false); return false; }
+        type = CBotTypResult(w, pClass);
     }
 
     if ( type.Eq( CBotTypArrayPointer ) ||
@@ -339,7 +344,10 @@ bool ReadType(std::istream &istr, CBotTypResult &type, CBotContext& context)
     {
         std::string className;
         if (!ReadString(istr, className)) return false;
-        type = CBotTypResult(w, className);
+        if (className.empty()) { assert(false); return false; }
+        auto pClass = context.FindClass(className);
+        if (pClass == nullptr) { assert(false); return false; }
+        type = CBotTypResult(w, pClass);
     }
     return true;
 }

--- a/CBot/src/CBot/CBotFileUtils.h
+++ b/CBot/src/CBot/CBotFileUtils.h
@@ -227,9 +227,6 @@ bool WriteStream(std::ostream &ostr, std::istream& istr);
  */
 bool ReadStream(std::istream& istr, std::ostream &ostr);
 
-bool WriteVarList(std::ostream &ostr, CBotVar* pVar, CBotContext& context);
-bool ReadVarList(std::istream &istr, CBotVar* &pVar, CBotContext& context);
-
 bool WriteVarListAsArray(std::ostream &ostr, CBotVar* pVar, CBotContext& context);
 bool ReadVarListFromArray(std::istream &istr, CBotVar* &pVar, CBotContext& context);
 

--- a/CBot/src/CBot/CBotFileUtils.h
+++ b/CBot/src/CBot/CBotFileUtils.h
@@ -21,21 +21,18 @@
 
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace CBot
 {
 
-class CBotVar;
+class CBotContext;
 class CBotTypResult;
+class CBotVar;
 
-/*!
- * \brief Save a linked list if variables
- * \param ostr Output stream
- * \param pVar First variable in the list
- * \return true on success
- */
-bool SaveVars(std::ostream &ostr, CBotVar* pVar);
+using CBotVarUPtr = std::unique_ptr<CBot::CBotVar>;
 
 /*!
  * \brief WriteWord
@@ -167,6 +164,22 @@ bool WriteDouble(std::ostream &ostr, double d);
 bool ReadDouble(std::istream &istr, double &d);
 
 /*!
+ * \brief WriteSize_t
+ * \param ostr Output stream
+ * \param s
+ * \return true on success
+ */
+bool WriteSize_t(std::ostream &ostr, std::size_t s);
+
+/*!
+ * \brief ReadSize_t
+ * \param istr Input stream
+ * \param s[out]
+ * \return true on success
+ */
+bool ReadSize_t(std::istream &istr, std::size_t &s);
+
+/*!
  * \brief WriteString
  * \param ostr Output stream
  * \param s
@@ -196,7 +209,7 @@ bool WriteType(std::ostream &ostr, const CBotTypResult &type);
  * \param[out] type
  * \return true on success
  */
-bool ReadType(std::istream &istr, CBotTypResult &type);
+bool ReadType(std::istream &istr, CBotTypResult &type, CBotContext& context);
 
 /*!
  * \brief WriteStream
@@ -213,5 +226,14 @@ bool WriteStream(std::ostream &ostr, std::istream& istr);
  * \return true on success
  */
 bool ReadStream(std::istream& istr, std::ostream &ostr);
+
+bool WriteVarList(std::ostream &ostr, CBotVar* pVar, CBotContext& context);
+bool ReadVarList(std::istream &istr, CBotVar* &pVar, CBotContext& context);
+
+bool WriteVarListAsArray(std::ostream &ostr, CBotVar* pVar, CBotContext& context);
+bool ReadVarListFromArray(std::istream &istr, CBotVar* &pVar, CBotContext& context);
+
+bool WriteVarArray(std::ostream &ostr, const std::vector<CBotVarUPtr>& vars, CBotContext& context);
+bool ReadVarArray(std::istream &istr, std::vector<CBotVarUPtr>& vars, CBotContext& context);
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotInstr/CBotCase.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotCase.cpp
@@ -55,7 +55,7 @@ CBotInstr* CBotCase::Compile(CBotToken* &p, CBotCStack* pStack, std::unordered_m
         {
             if (pStack->GetType() <= CBotTypLong)
             {
-                CBotStack* pile = CBotStack::AllocateStack();
+                CBotStack* pile = CBotStack::AllocateStack(pStack->GetContext());
                 while ( !i->Execute(pile) );
                 labelValue = pile->GetVar()->GetValLong();
                 pile->Delete();

--- a/CBot/src/CBot/CBotInstr/CBotDefClass.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotDefClass.cpp
@@ -195,12 +195,11 @@ CBotInstr* CBotDefClass::Compile(CBotToken* &p, CBotCStack* pStack, CBotClass* p
                 pStk->SetError(CBotErrBadType1, p->GetStart());
                 goto error;
             }
-//          if ( !bIntrinsic ) var->SetPointer(pStk->GetVar()->GetPointer());
             if ( !bIntrinsic )
             {
                 // does not use the result on the stack, to impose the class
                 CBotVar* pvar = CBotVar::Create("", pClass);
-                var->SetPointer( pvar );                    // variable already declared instance pointer
+                var->SetPointer( pvar->GetPointer() );      // variable already declared instance pointer
                 delete pvar;                                // removes the second pointer
             }
             var->SetInit(CBotVar::InitType::DEF);                         // marks the pointer as init
@@ -212,7 +211,7 @@ CBotInstr* CBotDefClass::Compile(CBotToken* &p, CBotCStack* pStack, CBotClass* p
             if ( !bIntrinsic )
             {
                 CBotVar* pvar = CBotVar::Create("", pClass);
-                var->SetPointer( pvar );                    // variable already declared instance pointer
+                var->SetPointer( pvar->GetPointer() );      // variable already declared instance pointer
                 delete pvar;                                // removes the second pointer
             }
             var->SetInit(CBotVar::InitType::IS_POINTER);                            // marks the pointer as init
@@ -301,7 +300,7 @@ bool CBotDefClass::Execute(CBotStack* &pj)
 
             if ( bIntrincic )
             {
-                if ( pv == nullptr || pv->GetPointer() == nullptr )
+                if ( pv == nullptr )
                 {
                     pile->SetError(CBotErrNull, &m_token);
                     return pj->Return(pile);
@@ -319,10 +318,8 @@ bool CBotDefClass::Execute(CBotStack* &pj)
                     }
                 }
 
-                CBotVarClass* pInstance;
-                pInstance = pv->GetPointer();    // value for the assignment
                 CBotTypResult type = pThis->GetTypResult();
-                pThis->SetPointer(pInstance);
+                pThis->SetPointer( pv->GetPointer() );
                 pThis->SetType(type);        // keep pointer type
             }
             pThis->SetInit(CBotVar::InitType::DEF);
@@ -339,10 +336,8 @@ bool CBotDefClass::Execute(CBotStack* &pj)
 
                 // creates an instance of the requested class
 
-                CBotVarClass* pInstance;
-                pInstance = static_cast<CBotVarClass*>(CBotVar::Create("", pClass));
-                pThis->SetPointer(pInstance);
-                delete pInstance;
+                CBotVarUPtr pInstance{CBotVar::Create("", pClass)};
+                pThis->SetPointer( pInstance->GetPointer() );
 
                 pile->IncState();
             }

--- a/CBot/src/CBot/CBotInstr/CBotDefClass.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotDefClass.cpp
@@ -64,11 +64,11 @@ CBotInstr* CBotDefClass::Compile(CBotToken* &p, CBotCStack* pStack, CBotClass* p
     if ( pClass == nullptr )
     {
         pStack->SetStartError(p->GetStart());
-        pClass = CBotClass::Find(p);
+        pClass = pStack->FindClass(p->GetString());
         if ( pClass == nullptr )
         {
             // not found? is bizare
-            pStack->SetError(CBotErrNotClass, p);
+            pStack->SetError(CBotErrNoClassName, p);
             return nullptr;
         }
         p = p->GetNext();
@@ -259,8 +259,7 @@ bool CBotDefClass::Execute(CBotStack* &pj)
         }
     }
 
-    CBotToken*  pt = &m_token;
-    CBotClass*  pClass = CBotClass::Find(pt);
+    auto pClass = pile->FindClass(m_token.GetString());
 
     bool bIntrincic = pClass->IsIntrinsic();
 
@@ -331,8 +330,7 @@ bool CBotDefClass::Execute(CBotStack* &pj)
 
             if ( !bIntrincic && pile->GetState() == 1)
             {
-                CBotToken*  pt = &m_token;
-                CBotClass* pClass = CBotClass::Find(pt);
+                auto pClass = pile->FindClass(m_token.GetString());
 
                 // creates an instance of the requested class
 
@@ -425,8 +423,7 @@ void CBotDefClass::RestoreState(CBotStack* &pj, bool bMain)
         }
     }
 
-    CBotToken*  pt = &m_token;
-    CBotClass*  pClass = CBotClass::Find(pt);
+    auto pClass = pile->FindClass(m_token.GetString());
     bool bIntrincic = pClass->IsIntrinsic();
 
     if ( bMain && pile->GetState()<3)
@@ -478,7 +475,7 @@ void CBotDefClass::RestoreState(CBotStack* &pj, bool bMain)
             ppVars[i] = nullptr;
 
             // creates a variable for the result
-            pClass->RestoreMethode(m_nMethodeIdent, pt, pThis, ppVars, pile2);
+            pClass->RestoreMethode(m_nMethodeIdent, &m_token, pThis, ppVars, pile2);
             return;
         }
     }

--- a/CBot/src/CBot/CBotInstr/CBotExprConstant.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotExprConstant.cpp
@@ -1,0 +1,174 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#include "CBot/CBotInstr/CBotExprConstant.h"
+
+#include "CBot/CBotCStack.h"
+#include "CBot/CBotStack.h"
+
+#include "CBot/CBotVar/CBotVar.h"
+
+#include "CBot/context/cbot_context.h"
+
+namespace CBot
+{
+
+template<>
+CBotExprConstant<signed char>::CBotExprConstant(signed char val) : m_type(CBotTypByte), m_value(val)
+{}
+
+template<>
+CBotExprConstant<short>::CBotExprConstant(short val) : m_type(CBotTypShort), m_value(val)
+{}
+
+template<>
+CBotExprConstant<char32_t>::CBotExprConstant(char32_t val) : m_type(CBotTypChar), m_value(val)
+{}
+
+template<>
+CBotExprConstant<int>::CBotExprConstant(int val) : m_type(CBotTypInt), m_value(val)
+{}
+
+template<>
+CBotExprConstant<long>::CBotExprConstant(long val) : m_type(CBotTypLong), m_value(val)
+{}
+
+template<>
+CBotExprConstant<float>::CBotExprConstant(float val) : m_type(CBotTypFloat), m_value(val)
+{}
+
+template<>
+CBotExprConstant<double>::CBotExprConstant(double val) : m_type(CBotTypDouble), m_value(val)
+{}
+
+template<>
+CBotExprConstant<std::string>::CBotExprConstant(std::string val) : m_type(CBotTypString), m_value(val)
+{}
+
+template<typename T>
+CBotExprConstant<T>::~CBotExprConstant()
+{}
+
+CBotInstr* CompileExprConstant(CBotToken* &p, CBotCStack* pStack)
+{
+    CBotCStack* pStk = pStack->TokenStack();
+
+    const auto& name = p->GetString();
+
+    if (p->GetType() != TokenTypDef)
+    {
+        assert(false);
+        return nullptr;
+    }
+
+    CBotInstr* inst = nullptr;
+
+    auto context = pStack->GetContext();
+    const auto& var = context->GetDefinedConstant(name);
+    if (var == nullptr)
+    {
+        assert(false);
+        return nullptr;
+    }
+
+    switch (var->GetType())
+    {
+        case CBotTypByte:
+            inst = new CBotExprConstant<signed char>(*var); break;
+
+        case CBotTypShort:
+            inst = new CBotExprConstant<short>(*var); break;
+
+        case CBotTypChar:
+            inst = new CBotExprConstant<char32_t>(*var); break;
+
+        case CBotTypInt:
+            inst = new CBotExprConstant<int>(*var); break;
+
+        case CBotTypLong:
+            inst = new CBotExprConstant<long>(*var); break;
+
+        case CBotTypFloat:
+            inst = new CBotExprConstant<float>(*var); break;
+
+        case CBotTypDouble:
+            inst = new CBotExprConstant<double>(*var); break;
+
+        case CBotTypString:
+            inst = new CBotExprConstant<std::string>(*var); break;
+
+        default:
+            assert(false);
+            return nullptr;
+    }
+
+    inst->SetToken(p);
+    p = p->GetNext();
+    pStk->SetCopyVar(var.get());
+    return pStack->Return(inst, pStk);
+}
+
+template<>
+bool CBotExprConstant<std::string>::Execute(CBotStack* &pj)
+{
+    CBotStack* pile = pj->AddStack(this);
+
+    if (pile->IfStep()) return false;
+
+    CBotVar* var = CBotVar::Create("", m_type);
+
+    *var = m_value;
+    pile->SetVar(var);
+    return pj->Return(pile);
+}
+
+template<typename T>
+bool CBotExprConstant<T>::Execute(CBotStack* &pj)
+{
+    CBotStack* pile = pj->AddStack(this);
+
+    if (pile->IfStep()) return false;
+
+    CBotVar* var = CBotVar::Create("", m_type);
+
+    if (m_type.Eq(CBotTypInt))
+    {
+        var->SetValInt(m_value, m_token.GetString());
+    }
+    else
+    {
+        *var = m_value;
+    }
+    pile->SetVar(var);
+    return pj->Return(pile);
+}
+
+template<typename T>
+void CBotExprConstant<T>::RestoreState(CBotStack* &pj, bool bMain)
+{
+    if (bMain) pj->RestoreStack(this);
+}
+
+template<typename T>
+std::string CBotExprConstant<T>::GetDebugData()
+{
+    return m_token.GetString();
+}
+
+} // namespace CBot

--- a/CBot/src/CBot/CBotInstr/CBotExprConstant.h
+++ b/CBot/src/CBot/CBotInstr/CBotExprConstant.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+#include "CBot/CBotInstr/CBotInstr.h"
+
+#include "CBot/CBotTypResult.h"
+
+namespace CBot
+{
+
+
+CBotInstr* CompileExprConstant(CBotToken* &p, CBotCStack* pStack);
+/**
+ * \brief A predefined constant (see CBotListConstant::AddConstant())
+ *
+ * Can be of type:
+ * ::CBotTypByte
+ * ::CBotTypShort
+ * ::CBotTypChar
+ * ::CBotTypInt
+ * ::CBotTypLong
+ * ::CBotTypFloat
+ * ::CBotTypDouble
+ * ::CBotTypString
+ */
+template<typename T>
+class CBotExprConstant : public CBotInstr
+{
+
+public:
+    CBotExprConstant(T val)
+    {
+        static_assert(sizeof(T) == 0, "Only specializations of CBotExprConstant can be used");
+    }
+
+    ~CBotExprConstant();
+
+    bool Execute(CBotStack* &pj) override;
+
+    void RestoreState(CBotStack* &pj, bool bMain) override;
+
+protected:
+    virtual const std::string GetDebugName() override { return "CBotExprConstant"; }
+    virtual std::string GetDebugData() override;
+
+private:
+    CBotTypResult m_type;
+    //! Value
+    const T m_value;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/CBotInstr/CBotExprRetVar.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotExprRetVar.cpp
@@ -155,7 +155,7 @@ bool CBotExprRetVar::Execute(CBotStack* &pj)
     if (pile1->GetState() == 0)
     {
         pVar = pj->GetVar();
-        pVar->Update(pj->GetUserPtr());
+        pVar->Update();
         if (pVar->GetType(CBotVar::GetTypeMode::CLASS_AS_POINTER) == CBotTypNullPointer)
         {
             pile1->SetError(CBotErrNull, &m_token);

--- a/CBot/src/CBot/CBotInstr/CBotExpression.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotExpression.cpp
@@ -193,7 +193,7 @@ bool CBotExpression::Execute(CBotStack* &pj)
             if (var->GetType() == CBotTypString && value->GetType() != CBotTypString)
             {
                 CBotVar* newVal = CBotVar::Create("", var->GetTypResult());
-                value->Update(pj->GetUserPtr());
+                value->Update();
                 newVal->SetValString(value->GetValString());
                 pile2->SetVar(newVal);
             }

--- a/CBot/src/CBot/CBotInstr/CBotFunction.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotFunction.cpp
@@ -433,7 +433,7 @@ bool CBotFunction::Execute(CBotVar** ppVars, CBotStack* &pj, CBotVar* pInstance)
             }
 
             pThis = CBotVar::Create("this", CBotTypResult( CBotTypPointer, m_MasterClass ));
-            pThis->SetPointer(pInstance);
+            pThis->SetPointer( pInstance->GetPointer() );
         }
         assert(pThis != nullptr);
         pThis->SetInit(CBotVar::InitType::IS_POINTER);
@@ -494,7 +494,7 @@ void CBotFunction::RestoreState(CBotVar** ppVars, CBotStack* &pj, CBotVar* pInst
     {
         CBotVar* pThis = pile->FindVar("this");
         pThis->SetInit(CBotVar::InitType::IS_POINTER);
-        pThis->SetPointer(pInstance);
+        pThis->SetPointer( pInstance->GetPointer() );
         pThis->SetUniqNum(-2);
     }
 
@@ -790,7 +790,7 @@ int CBotFunction::DoCall(CBotProgram* program, const std::list<CBotFunction*>& l
                     }
 
                     pThis = CBotVar::Create("this", CBotTypResult( CBotTypPointer, pt->m_MasterClass ));
-                    pThis->SetPointer(pInstance);
+                    pThis->SetPointer( pInstance->GetPointer() );
                 }
                 assert(pThis != nullptr);
                 pThis->SetInit(CBotVar::InitType::IS_POINTER);
@@ -874,7 +874,7 @@ void CBotFunction::RestoreCall(const std::list<CBotFunction*>& localFunctionList
                 // make "this" known
                 CBotVar* pThis = pStk1->FindVar("this");
                 pThis->SetInit(CBotVar::InitType::IS_POINTER);
-                pThis->SetPointer(pInstance);
+                pThis->SetPointer( pInstance->GetPointer() );
                 pThis->SetUniqNum(-2);
             }
         }

--- a/CBot/src/CBot/CBotInstr/CBotFunction.h
+++ b/CBot/src/CBot/CBotInstr/CBotFunction.h
@@ -146,17 +146,6 @@ public:
                            std::map<CBotFunction*, int>& funcMap, CBotClass* pClass = nullptr);
 
     /*!
-     * \brief Find all public functions that match the name and arguments.
-     * \param name Name of the function to find.
-     * \param ppVars Arguments to compare with parameters.
-     * \param TypeOrError Contains a CBotError when no useable function has been found.
-     * \param funcMap Container for suitable functions and their signature values.
-     * \param pClass Pointer to class when searching for methods.
-     */
-    static void SearchPublic(const std::string& name, CBotVar** ppVars, CBotTypResult& TypeOrError,
-                             std::map<CBotFunction*, int>& funcMap, CBotClass* pClass = nullptr);
-
-    /*!
      * \brief Find the function with the lowest signature value. If there is more
      * than one of the same signature value, TypeOrError is set to CBotErrAmbiguousCall.
      * \param funcMap List of functions and their signature values, can be empty.
@@ -252,12 +241,6 @@ public:
      * \return
      */
     bool CheckParam(CBotDefParam* pParam);
-
-    /*!
-     * \brief AddPublic
-     * \param pfunc
-     */
-    static void AddPublic(CBotFunction* pfunc);
 
     /*!
      * \brief GetName
@@ -358,13 +341,11 @@ private:
     CBotToken m_openblk;
     CBotToken m_closeblk;
 
-    //! List of public functions
-    static std::set<CBotFunction*> m_publicFunctions;
-
     friend class CBotProgram;
     friend class CBotClass;
     friend class CBotCStack;
 
+    std::weak_ptr<CBotContext> m_context;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotInstr/CBotIndexExpr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotIndexExpr.cpp
@@ -91,7 +91,7 @@ bool CBotIndexExpr::ExecuteVar(CBotVar* &pVar, CBotStack* &pile, CBotToken* prev
         return pj->Return(pile);
     }
 
-    pVar->Update(pile->GetUserPtr());
+    pVar->Update();
 
     if ( m_next3 != nullptr &&
          !m_next3->ExecuteVar(pVar, pile, prevToken, bStep, bExtend) ) return false;

--- a/CBot/src/CBot/CBotInstr/CBotInstr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotInstr.cpp
@@ -260,7 +260,7 @@ CBotInstr* CBotInstr::Compile(CBotToken* &p, CBotCStack* pStack)
     CBotToken*    ppp = p;
     if (IsOfType(ppp, TokenTypVar))
     {
-        if (CBotClass::Find(p) != nullptr) // Does class with this name exist?
+        if (pStack->FindClass(p->GetString()) != nullptr) // Does class with this name exist?
         {
             // Yes, compile the declaration of the instance
             return CBotDefClass::Compile(p, pStack);

--- a/CBot/src/CBot/CBotInstr/CBotInstr.h
+++ b/CBot/src/CBot/CBotInstr/CBotInstr.h
@@ -27,6 +27,7 @@
 namespace CBot
 {
 class CBotDebug;
+class CBotStack;
 
 /**
  * \brief Class for one CBot instruction

--- a/CBot/src/CBot/CBotInstr/CBotInstrMethode.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotInstrMethode.cpp
@@ -174,7 +174,7 @@ bool CBotInstrMethode::ExecuteVar(CBotVar* &pVar, CBotStack* &pj, CBotToken* pre
     CBotClass*  pClass;
 
     if (m_thisIdent == -3) // super.method()
-        pClass = CBotClass::Find(m_className);
+        pClass = pile1->FindClass(m_className);
     else
         pClass = pThis->GetClass();
 
@@ -247,7 +247,7 @@ void CBotInstrMethode::RestoreStateVar(CBotStack* &pile, bool bMain)
     CBotClass*    pClass;
 
     if (m_thisIdent == -3) // super.method()
-        pClass = CBotClass::Find(m_className);
+        pClass = pile1->FindClass(m_className);
     else
         pClass = pThis->GetClass();
 
@@ -302,7 +302,7 @@ bool CBotInstrMethode::Execute(CBotStack* &pj)
     CBotClass*  pClass;
 
     if (m_thisIdent == -3) // super.method()
-        pClass = CBotClass::Find(m_className);
+        pClass = pile1->FindClass(m_className);
     else
         pClass = pThis->GetClass();
 

--- a/CBot/src/CBot/CBotInstr/CBotLeftExprVar.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotLeftExprVar.cpp
@@ -66,7 +66,7 @@ bool CBotLeftExprVar::Execute(CBotStack* &pj)
     {
         if (m_typevar.Eq(CBotTypString) && var2->GetType() != CBotTypString)
         {
-            var2->Update(pj->GetUserPtr());
+            var2->Update();
             var1->SetValString(var2->GetValString());
             return true;
         }

--- a/CBot/src/CBot/CBotInstr/CBotNew.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotNew.cpp
@@ -60,7 +60,7 @@ CBotInstr* CBotNew::Compile(CBotToken* &p, CBotCStack* pStack)
         return nullptr;
     }
 
-    CBotClass* pClass = CBotClass::Find(p);
+    auto pClass = pStack->FindClass(p->GetString());
     if (pClass == nullptr)
     {
         pStack->SetError(CBotErrBadNew, p);
@@ -147,8 +147,7 @@ bool CBotNew::Execute(CBotStack* &pj)
 
     CBotVar*    pThis = nullptr;
 
-    CBotToken*    pt = &m_vartoken;
-    CBotClass*    pClass = CBotClass::Find(pt);
+    auto pClass = pile->FindClass(m_vartoken.GetString());
 
     // create the variable "this" pointer type to the stack
 
@@ -239,8 +238,7 @@ void CBotNew::RestoreState(CBotStack* &pj, bool bMain)
 
     CBotStack*    pile1 = pj->AddStack2();  //secondary stack
 
-    CBotToken*    pt = &m_vartoken;
-    CBotClass*    pClass = CBotClass::Find(pt);
+    auto pClass = pile->FindClass(m_vartoken.GetString());
 
     // create the variable "this" pointer type to the object
 

--- a/CBot/src/CBot/CBotInstr/CBotParExpr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotParExpr.cpp
@@ -20,6 +20,7 @@
 #include "CBot/CBotInstr/CBotParExpr.h"
 
 #include "CBot/CBotInstr/CBotExpression.h"
+#include "CBot/CBotInstr/CBotExprConstant.h"
 #include "CBot/CBotInstr/CBotExprLitBool.h"
 #include "CBot/CBotInstr/CBotExprLitChar.h"
 #include "CBot/CBotInstr/CBotExprLitNan.h"
@@ -160,11 +161,17 @@ CBotInstr* CBotParExpr::CompileLitExpr(CBotToken* &p, CBotCStack* pStack)
     if (inst != nullptr || !pStk->IsOk())
         return pStack->Return(inst, pStk);
 
-    // is it a number or DefineNum?
-    if (p->GetType() == TokenTypNum ||
-        p->GetType() == TokenTypDef )
+    // is it a number?
+    if (p->GetType() == TokenTypNum)
     {
         CBotInstr* inst = CBot::CompileExprLitNum(p, pStk);
+        return pStack->Return(inst, pStk);
+    }
+
+    // is it a defined constant?
+    if (p->GetType() == TokenTypDef)
+    {
+        CBotInstr* inst = CBot::CompileExprConstant(p, pStk);
         return pStack->Return(inst, pStk);
     }
 
@@ -255,11 +262,17 @@ CBotInstr* CBotParExpr::CompileConstExpr(CBotToken* &p, CBotCStack* pStack)
     if (inst != nullptr || !pStk->IsOk())
         return pStack->Return(inst, pStk);
 
-    // is it a number or DefineNum?
-    if (p->GetType() == TokenTypNum ||
-        p->GetType() == TokenTypDef )
+    // is it a number?
+    if (p->GetType() == TokenTypNum)
     {
         CBotInstr* inst = CBot::CompileExprLitNum(p, pStk);
+        return pStack->Return(inst, pStk);
+    }
+
+    // is it a defined constant?
+    if (p->GetType() == TokenTypDef)
+    {
+        CBotInstr* inst = CBot::CompileExprConstant(p, pStk);
         return pStack->Return(inst, pStk);
     }
 

--- a/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotTwoOpExpr.cpp
@@ -425,8 +425,8 @@ bool CBotTwoOpExpr::Execute(CBotStack* &pStack)
     }
     else
     {
-        left->Update(nullptr);
-        right->Update(nullptr);
+        left->Update();
+        right->Update();
     }
 
     if ( GetTokenType() == ID_ADD && type1.Eq(CBotTypString) )

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -17,6 +17,8 @@
  * along with this program. If not, see http://gnu.org/licenses
  */
 
+#include "CBot/CBotProgram.h"
+
 #include "CBot/CBotVar/CBotVar.h"
 
 #include "CBot/CBotExternalCall.h"
@@ -52,7 +54,7 @@ CBotProgram::~CBotProgram()
         c->Purge();
     m_classes.clear();
 
-    CBotClass::FreeLock(this);
+    m_context->FreeLock(this);
 
     for (CBotFunction* f : m_functions) delete f;
     m_functions.clear();
@@ -212,7 +214,7 @@ bool CBotProgram::Run(void* pUser, int timer)
         m_error = m_stack->GetError(m_errorStart, m_errorEnd);
         m_stack->Delete();
         m_stack = nullptr;
-        CBotClass::FreeLock(this);
+        m_context->FreeLock(this);
         m_entryPoint = nullptr;
         return true;                                // execution is finished!
     }
@@ -228,7 +230,7 @@ void CBotProgram::Stop()
         m_stack = nullptr;
     }
     m_entryPoint = nullptr;
-    CBotClass::FreeLock(this);
+    m_context->FreeLock(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -351,16 +353,6 @@ bool CBotProgram::RestoreState(std::istream &istr)
 int CBotProgram::GetVersion()
 {
     return  CBOTVERSION;
-}
-
-void CBotProgram::Init()
-{
-    InitFileFunctions();
-}
-
-void CBotProgram::Free()
-{
-    CBotClass::ClearPublic();
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -94,7 +94,10 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
         {
             CBotClass* newclass = CBotClass::Compile1(p, pStack.get());
             if (newclass != nullptr)
+            {
+                newclass->SetContext(m_context);
                 m_classes.push_back(newclass);
+            }
         }
         else
         {
@@ -159,7 +162,7 @@ bool CBotProgram::Start(const std::string& name)
     }
     m_entryPoint = *it;
 
-    m_stack = CBotStack::AllocateStack();
+    m_stack = CBotStack::AllocateStack(m_context.get());
     m_stack->SetProgram(this);
 
     return true; // we are ready for Run()
@@ -369,7 +372,7 @@ bool CBotProgram::RestoreState(std::istream &istr)
     {
         m_stack->Delete();
         m_stack = nullptr;
-        m_stack = CBotStack::AllocateStack(); // start from the top
+        m_stack = CBotStack::AllocateStack(m_context.get()); // start from the top
         m_stack->SetProgram(this);
         return false; // signal error
     }

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -38,12 +38,14 @@
 namespace CBot
 {
 
-CBotProgram::CBotProgram()
+CBotProgram::CBotProgram(const CBotContextSPtr& context) :
+    CBotContextOwner(context)
 {
 }
 
-CBotProgram::CBotProgram(CBotVar* thisVar)
-: m_thisVar(thisVar)
+CBotProgram::CBotProgram(const CBotContextSPtr& context, CBotVar* thisVar) :
+    CBotContextOwner(context),
+    m_thisVar(thisVar)
 {
 }
 
@@ -76,11 +78,6 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
     externFunctions.clear();
     m_error = CBotNoErr;
 
-    if ( !m_context )
-    {
-        m_context = CBotContext::Create(nullptr);
-    }
-
     // Step 1. Process the code into tokens
     auto tokens = CBotToken::CompileTokens(program, *m_context);
     if (tokens == nullptr) return false;
@@ -102,7 +99,6 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
             CBotClass* newclass = CBotClass::Compile1(p, pStack.get());
             if (newclass != nullptr)
             {
-                newclass->SetContext(m_context);
                 m_classes.push_back(newclass);
             }
         }
@@ -158,7 +154,7 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
         m_functions.clear();
     }
 
-    return !externFunctions.empty();
+    return !m_functions.empty();
 }
 
 bool CBotProgram::Start(const std::string& name)

--- a/CBot/src/CBot/CBotProgram.cpp
+++ b/CBot/src/CBot/CBotProgram.cpp
@@ -141,7 +141,11 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
         {
             CBotFunction::Compile(p, pStack.get(), *next);
             if ((*next)->IsExtern()) externFunctions.push_back((*next)->GetName()/* + next->GetParams()*/);
-            if ((*next)->IsPublic()) CBotFunction::AddPublic(*next);
+            if ((*next)->IsPublic())
+            {
+                (*next)->m_context = m_context;
+                m_context->AddPublicFunction(*next);
+            }
             (*next)->m_pProg = this;                           // keeps pointers to the module
             ++next;
         }
@@ -154,7 +158,7 @@ bool CBotProgram::Compile(const std::string& program, std::vector<std::string>& 
         m_functions.clear();
     }
 
-    return !m_functions.empty();
+    return !externFunctions.empty();
 }
 
 bool CBotProgram::Start(const std::string& name)

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -212,72 +212,6 @@ public:
     void Stop();
 
     /**
-     * \brief Add a function that can be called from CBot
-     *
-     * To define an external function, proceed as follows:
-     *
-     * 1. Define a function for compilation
-     *
-     * This function should take a list of function arguments (types only, no values!) and a user-defined void* pointer (can be passed in Compile()) as parameters, and return CBotTypResult.
-     *
-     * Usually, name of this function is prefixed with "c".
-     *
-     * The function should iterate through the provided parameter list and verify that they match.<br>
-     * If they don't, then return CBotTypResult with an appropariate error code (see ::CBotError).<br>
-     * If they do, return CBotTypResult with the function's return type
-     *
-     * \code
-     * CBotTypResult cMessage(CBotVar* &var, void* user)
-     * {
-     *     if (var == nullptr) return CBotTypResult(CBotErrLowParam); // Not enough parameters
-     *     if (var->GetType() != CBotTypString) return CBotTypResult(CBotErrBadString); // String expected
-     *
-     *     var = var->GetNext(); // Get the next parameter
-     *     if (var != nullptr) return CBotTypResult(CBotErrOverParam); // Too many parameters
-     *
-     *     return CBotTypResult(CBotTypFloat); // This function returns float (it may depend on parameters given!)
-     * }
-     * \endcode
-     *
-     * 2. Define a function for execution
-     *
-     * This function should take:
-     * * a list of parameters
-     * * pointer to a result variable (a variable of type given at compilation time will be provided)
-     * * pointer to an exception variable
-     * * user-defined pointer (can be passed in Run())
-     *
-     * This function returns true if execution of this function is finished, or false to suspend the program and call this function again on next Run() cycle.
-     *
-     * Usually, execution functions are prefixed with "r".
-     *
-     * \code
-     * bool rMessage(CBotVar* var, CBotVar* result, int& exception, void* user)
-     * {
-     *     std::string message = var->GetValString();
-     *     std::cout << message << std::endl;
-     *     return true; // Execution finished
-     * }
-     * \endcode
-     *
-     * 3. Call AddFunction() to register the function in the CBot engine
-     *
-     * \code
-     * AddFunction("message", rMessage, cMessage);
-     * \endcode
-     *
-     * For more sophisticated examples, see the Colobot source code, mainly the src/script/scriptfunc.cpp file
-     *
-     * \param name Name of the function
-     * \param rExec Execution function
-     * \param rCompile Compilation function
-     * \return true
-     */
-    static bool AddFunction(const std::string& name,
-                            bool rExec(CBotVar* pVar, CBotVar* pResult, int& Exception, void* pUser),
-                            CBotTypResult rCompile(CBotVar*& pVar, void* pUser));
-
-    /**
      * \brief Save the current execution status into a file
      * \param ostr Output stream
      * \return true on success, false on write error
@@ -329,14 +263,7 @@ public:
      */
     bool ClassExists(std::string name);
 
-    /**
-     * \brief Returns static list of all registered external calls
-     */
-    static const std::unique_ptr<CBotExternalCallList>& GetExternalCalls();
-
 private:
-    //! All external calls
-    static std::unique_ptr<CBotExternalCallList> m_externalCalls;
     //! All user-defined functions
     std::list<CBotFunction*> m_functions{};
     //! The entry point function

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -48,9 +48,7 @@ class CBotExternalCallList;
  * * CBotContext
  *
  * Afterwards, you can start defining custom functions, constants and classes. See:
- * * CBotProgram::AddFunction()
- * * CBotProgram::DefineNum()
- * * CBotClass::Create()
+ * * CBotContext::AddConstant()
  *
  * Next, compile and run programs.
  * * SetContext()
@@ -278,12 +276,6 @@ public:
     static bool AddFunction(const std::string& name,
                             bool rExec(CBotVar* pVar, CBotVar* pResult, int& Exception, void* pUser),
                             CBotTypResult rCompile(CBotVar*& pVar, void* pUser));
-
-    /**
-     * \copydoc CBotToken::DefineNum()
-     * \see CBotToken::DefineNum()
-     */
-    static bool DefineNum(const std::string& name, long val);
 
     /**
      * \brief Save the current execution status into a file

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -41,39 +41,33 @@ class CBotExternalCallList;
 /**
  * \brief Class that manages a CBot program. This is the main entry point into the CBot engine.
  *
- * \section Init Engine initialization / destruction
- * To initialize the CBot engine, call CBotProgram::Init(). This function should be only called once.
- *
  * Create context for public functions, classes, etc. See:
  * * CBotContext
  *
  * Afterwards, you can start defining custom functions, constants and classes. See:
+ * * CBotContext::AddFunction()
  * * CBotContext::AddConstant()
+ * * CBotContext::CreateClass()
  *
  * Next, compile and run programs.
- * * SetContext()
  * * Compile()
  * * Start()
  * * Run()
  * * Stop()
  *
- * After you are finished, free the memory used by the CBot engine by calling CBotProgram::Free().
  *
  * \section Example Example usage
  * \code
- * // Initialize the engine
- * CBotProgram::Init();
  *
  * // Create context for public functions, classes, etc.
- * auto context = CBotContext::Create();
+ * auto context = CBotContext::CreateGlobalContext();
  *
  * // Add some standard functions
- * CBotProgram::AddFunction("message", rMessage, cMessage);
+ * context->AddFunction("message", rMessage, cMessage);
  *
  * // Compile the program
  * std::vector<std::string> externFunctions;
- * CBotProgram* program = new CBotProgram();
- * program->SetContext(context);
+ * CBotProgram* program = new CBotProgram(context);
  *
  * bool ok = program->Compile(code.c_str(), externFunctions, nullptr);
  * if (!ok)
@@ -88,8 +82,6 @@ class CBotExternalCallList;
  * program->Start(externFunctions[0]);
  * while (!program->Run());
  *
- * // Cleanup
- * CBotProgram::Free();
  * \endcode
  */
 class CBotProgram : public CBotContextOwner
@@ -97,14 +89,16 @@ class CBotProgram : public CBotContextOwner
 public:
     /**
      * \brief Constructor
+     * \param context
      */
-    CBotProgram();
+    CBotProgram(const CBotContextSPtr& context);
 
     /**
      * \brief Constructor
+     * \param context
      * \param thisVar Variable to pass to the program as "this"
      */
-    CBotProgram(CBotVar* thisVar);
+    CBotProgram(const CBotContextSPtr& context, CBotVar* thisVar);
 
     /**
      * \brief Destructor

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -21,6 +21,8 @@
 
 #include "CBot/CBotEnums.h"
 
+#include "CBot/context/context_owner.h"
+
 #include <list>
 #include <memory>
 #include <string>
@@ -42,12 +44,16 @@ class CBotExternalCallList;
  * \section Init Engine initialization / destruction
  * To initialize the CBot engine, call CBotProgram::Init(). This function should be only called once.
  *
+ * Create context for public functions, classes, etc. See:
+ * * CBotContext
+ *
  * Afterwards, you can start defining custom functions, constants and classes. See:
  * * CBotProgram::AddFunction()
  * * CBotProgram::DefineNum()
  * * CBotClass::Create()
  *
  * Next, compile and run programs.
+ * * SetContext()
  * * Compile()
  * * Start()
  * * Run()
@@ -60,12 +66,17 @@ class CBotExternalCallList;
  * // Initialize the engine
  * CBotProgram::Init();
  *
+ * // Create context for public functions, classes, etc.
+ * auto context = CBotContext::Create();
+ *
  * // Add some standard functions
  * CBotProgram::AddFunction("message", rMessage, cMessage);
  *
  * // Compile the program
  * std::vector<std::string> externFunctions;
  * CBotProgram* program = new CBotProgram();
+ * program->SetContext(context);
+ *
  * bool ok = program->Compile(code.c_str(), externFunctions, nullptr);
  * if (!ok)
  * {
@@ -83,7 +94,7 @@ class CBotExternalCallList;
  * CBotProgram::Free();
  * \endcode
  */
-class CBotProgram
+class CBotProgram : public CBotContextOwner
 {
 public:
     /**

--- a/CBot/src/CBot/CBotProgram.h
+++ b/CBot/src/CBot/CBotProgram.h
@@ -112,16 +112,6 @@ public:
     ~CBotProgram();
 
     /**
-     * \brief Initializes the module, should be done once (and only once) at the beginning
-     */
-    static void Init();
-
-    /**
-     * \brief Frees the static memory areas
-     */
-    static void Free();
-
-    /**
      * \brief Returns version of the CBot library
      * \return A number representing the current library version
      */

--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -607,7 +607,7 @@ bool CBotStack::ExecuteCall(long& nIdent, CBotToken* token, CBotVar** ppVar, con
     // if not found (recompile?) seeks by name
 
     nIdent = 0;
-    res = m_prog->GetExternalCalls()->DoCall(token, nullptr, ppVar, this, rettype);
+    res = m_data->context->DoCall(token, nullptr, ppVar, this, rettype);
     if (res >= 0) return res;
 
     res = CBotFunction::DoCall(m_prog, m_prog->GetFunctions(), nIdent, token->GetString(), ppVar, this, token);
@@ -622,7 +622,7 @@ void CBotStack::RestoreCall(long& nIdent, CBotToken* token, CBotVar** ppVar)
 {
     if (m_next == nullptr) return;
 
-    if (m_prog->GetExternalCalls()->RestoreCall(token, nullptr, ppVar, this))
+    if (m_data->context->RestoreCall(token, nullptr, ppVar, this))
         return;
 
     CBotFunction::RestoreCall(m_prog->GetFunctions(), nIdent, token->GetString(), ppVar, this);

--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -729,7 +729,7 @@ bool CBotStack::SaveState(std::ostream &ostr)
     if (!WriteWord(ostr, 0)) return false; // for backwards combatibility (m_bDontDelete)
     if (!WriteInt(ostr, m_step)) return false;
 
-    if (!WriteVarList(ostr, m_var, *(m_data->context))) return false;            // current result
+    if (!WriteVarListAsArray(ostr, m_var, *(m_data->context))) return false;     // current result
     if (!WriteVarListAsArray(ostr, m_listVar, *(m_data->context))) return false; // local variables
 
     if (m_next != nullptr)
@@ -771,7 +771,7 @@ bool CBotStack::RestoreState(std::istream &istr, CBotStack* &pStack)
     if (!ReadInt(istr, state)) return false;
     pStack->m_step = state;
 
-    if (!ReadVarList(istr, pStack->m_var, *(m_data->context))) return false;              // temp variable
+    if (!ReadVarListFromArray(istr, pStack->m_var, *(m_data->context))) return false;     // temp variable
     if (!ReadVarListFromArray(istr, pStack->m_listVar, *(m_data->context))) return false; // local variables
 
     return pStack->RestoreState(istr, pStack->m_next);
@@ -804,7 +804,7 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
     outVar.reset();
     {
         if (!ReadWord(istr, w)) return false;                      // private or type?
-        if ( w == 0 ) return true; // 0 - CBot::WriteVarList terminator
+        if ( w == 0 ) return true; // 0 - list terminator or saved nullptr
 
         std::string defnum;
         if ( w == 200 )
@@ -954,7 +954,7 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
 
                 // returns the original instance
                 CBotVar* pInstance = nullptr;
-                if (!ReadVarList(istr, pInstance, context)) return false;
+                if (!ReadVarListFromArray(istr, pInstance, context)) return false;
 
                 if (pInstance != nullptr)
                 {
@@ -975,7 +975,7 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
 
                 // returns the original instance
                 CBotVar* pInstance = nullptr;
-                if (!ReadVarList(istr, pInstance, context)) return false;
+                if (!ReadVarListFromArray(istr, pInstance, context)) return false;
 
                 if (pInstance != nullptr)
                 {

--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -26,8 +26,9 @@
 #include "CBot/CBotVar/CBotVarPointer.h"
 #include "CBot/CBotVar/CBotVarClass.h"
 
-#include "CBot/CBotUtils.h"
 #include "CBot/CBotExternalCall.h"
+#include "CBot/CBotUtils.h"
+#include "CBot/CBotProgram.h"
 
 #include "CBot/context/cbot_context.h"
 #include "CBot/context/cbot_user_pointer.h"
@@ -947,7 +948,7 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
             std::string className;
             if (!ReadString(istr, className)) return false; // name of the class
             {
-                auto pClass = CBotClass::Find(className);
+                auto pClass = context.FindClass(className);
                 CBotTypResult ptrType(w, pClass);
                 pNew = CBotVar::Create(token, ptrType);        // creates a variable
 
@@ -998,6 +999,11 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
 bool CBotStack::IsCallFinished()
 {
     return m_callFinished;
+}
+
+CBotClass* CBotStack::FindClass(const std::string& name)
+{
+    return m_data->context->FindClass(name);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -901,45 +901,56 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
             isClass = true;
         case CBotTypArrayBody:
             {
-                int isExisting;
-                if (!ReadInt(istr, isExisting)) return false;
-                if (isExisting != 0)
+                int id;
+                if (!ReadInt(istr, id)) return false;
+                if (id != 0) // found a reference to an existing object
                 {
-                    int id;
-                    if (!ReadInt(istr, id)) return false;
                     CBotVar* pInstance = context.FindInstance(id);
                     if (pInstance == nullptr)
                     {
                         assert(false);
                         return false;
                     }
-                    pNew = pInstance;
+                    if (!isClass)
+                        pNew = CBotVar::Create("", {CBotTypArrayPointer, pInstance->GetTypResult().GetTypElem()});
+                    else
+                        pNew = CBotVar::Create("", CBotTypNullPointer, nullptr);
+
+                    pNew->SetPointer( pInstance->GetPointer() ); // get shared ptr
                     break;
                 }
 
-                int id;
-                if (!ReadInt(istr, id)) return false;
+                // found the original object
                 CBotTypResult    r;
                 if (!ReadType(istr, r, context)) return false;      // complete type
 
-                pNew = new CBotVarClass(token, r);                // directly creates an instance
+                // create a new object or pointer to a new instance
+                CBotVarUPtr newObject{ CBotVar::Create(token, r) };
+
+                CBotVarClass* newInstance;
                 auto pClass = r.GetClass();
-                if (pClass == nullptr || !pClass->IsIntrinsic())
+                if (isClass && pClass->IsIntrinsic()) // is pass-by-copy object like 'point'
                 {
-                    context.DeclareInstance(id, pNew);
+                    newInstance = static_cast<CBotVarClass*>(newObject.get());
+                }
+                else  // (is pointer) to new array or new class instance
+                {
+                    newInstance = static_cast<CBotVarClass*>(newObject->GetPointer().get());
+                    context.DeclareInstance(newInstance); // restore unique 'id' before reading saved fields
                 }
 
-                if (!ReadVarListFromArray(istr, (static_cast<CBotVarClass*>(pNew))->m_pVar, context)) return false;
+                if (!ReadVarListFromArray(istr, newInstance->m_pVar, context)) return false;
 
                 if (isClass) // read id for each item in this instance
                 {
-                    CBotVar* pVars = (static_cast<CBotVarClass*>(pNew))->m_pVar;
+                    CBotVar* pVars = newInstance->m_pVar;
                     while (pVars != nullptr)
                     {
                         if (!ReadLong(istr, pVars->m_ident)) return false;
                         pVars = pVars->m_next;
                     }
                 }
+                pNew = newObject.release();
             }
             break;
 
@@ -953,13 +964,13 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
                 CBotTypResult ptrType(w, pClass);
                 pNew = CBotVar::Create(token, ptrType);        // creates a variable
 
-                // returns the original instance
-                CBotVar* pInstance = nullptr;
-                if (!ReadVarListFromArray(istr, pInstance, context)) return false;
+                // expecting nullptr or pointer with ownership of the instance
+                CBotVarUPtr temp;
+                if (!RestoreVar(istr, temp, context)) return false;
 
-                if (pInstance != nullptr)
+                if (temp)
                 {
-                    pNew->SetPointer( pInstance->GetPointer() );            // and point over
+                    pNew->SetPointer( temp->GetPointer() ); // get shared ptr
                 }
 
                 if (bConstructor) pNew->ConstructorSet(); // constructor was called
@@ -974,13 +985,13 @@ bool CBotVar::RestoreVar(std::istream &istr, CBotVarUPtr& outVar, CBotContext& c
 
                 pNew = CBotVar::Create(token, r);                        // creates a variable
 
-                // returns the original instance
-                CBotVar* pInstance = nullptr;
-                if (!ReadVarListFromArray(istr, pInstance, context)) return false;
+                // expecting nullptr or pointer with ownership of the instance
+                CBotVarUPtr temp;
+                if (!RestoreVar(istr, temp, context)) return false;
 
-                if (pInstance != nullptr)
+                if (temp)
                 {
-                    pNew->SetPointer( pInstance->GetPointer() );            // and point over
+                    pNew->SetPointer( temp->GetPointer() ); // get shared ptr
                 }
             }
             break;

--- a/CBot/src/CBot/CBotStack.h
+++ b/CBot/src/CBot/CBotStack.h
@@ -30,6 +30,7 @@
 namespace CBot
 {
 
+class CBotContext;
 class CBotInstr;
 class CBotExternalCall;
 class CBotVar;
@@ -64,7 +65,7 @@ public:
      * \brief Allocate the stack
      * \return pointer to created stack
      */
-    static CBotStack* AllocateStack();
+    static CBotStack* AllocateStack(CBotContext* context);
 
     /** \brief Remove the current stack */
     void Delete();

--- a/CBot/src/CBot/CBotStack.h
+++ b/CBot/src/CBot/CBotStack.h
@@ -30,6 +30,7 @@
 namespace CBot
 {
 
+class CBotClass;
 class CBotContext;
 class CBotInstr;
 class CBotExternalCall;
@@ -464,6 +465,8 @@ public:
 
     bool            IsCallFinished();
 
+    CBotClass*      FindClass(const std::string& name);
+
 private:
     CBotStack*        m_next;
     CBotStack*        m_next2;
@@ -492,6 +495,14 @@ private:
     CBotExternalCall* m_call;
 
     bool m_callFinished;
+};
+
+struct CBotStackDeleter
+{
+    void operator()(CBotStack* p)
+    {
+        if (p != nullptr) p->Delete();
+    }
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotToken.h
+++ b/CBot/src/CBot/CBotToken.h
@@ -28,6 +28,8 @@
 
 namespace CBot
 {
+
+class CBotContext;
 class CBotToken;
 
 using CBotTokenUPtr = std::unique_ptr<CBotToken>;
@@ -168,21 +170,8 @@ public:
      * \return The first token in the linked list
      */
     static CBotTokenUPtr CompileTokens(const std::string& program,
+                                       const CBotContext& context,
                                        CBotToken::Data* tokendata = nullptr);
-
-    /**
-     * \brief Define a new constant
-     * \param name Name of the constant
-     * \param val Value of the constant
-     * \return true on success, false if already defined
-     */
-    static bool DefineNum(const std::string& name, long val);
-
-    /**
-     * \brief Clear the list of defined constants
-     * \see DefineNum()
-     */
-    static void ClearDefineNum();
 
     /**
      * \brief Generate a CRC32 signature for a sequence of tokens.
@@ -221,9 +210,6 @@ private:
     //! The end position of the token in the CBotProgram
     int m_end = 0;
 
-    //! Map of all defined constants (see DefineNum())
-    static std::map<std::string, long> m_defineNum;
-
     /**
      * \brief Check if the word is a keyword
      * \param w The word to check
@@ -231,13 +217,6 @@ private:
      */
     static int GetKeyWord(const std::string& w);
 
-    /**
-     * \brief Resolve a constant defined with DefineNum()
-     * \param name Constant name
-     * \param token Token that we are working on, will be filled with data about found constant
-     * \return true if the constant was found, false otherwise
-     */
-    static bool GetDefineNum(const std::string& name, CBotToken* token);
 };
 
 /**

--- a/CBot/src/CBot/CBotTypResult.cpp
+++ b/CBot/src/CBot/CBotTypResult.cpp
@@ -32,6 +32,13 @@ namespace CBot
 CBotTypResult::CBotTypResult(int type)
     : m_type(type)
 {
+    // only primitive types, CBotTypNullPointer, or CBotError allowed
+    // other types must use a different constructor
+    assert( type != CBotTypArrayPointer );
+    assert( type != CBotTypArrayBody );
+    assert( type != CBotTypIntrinsic );
+    assert( type != CBotTypPointer );
+    assert( type != CBotTypClass );
 }
 
 CBotTypResult::CBotTypResult(int type, const std::string& name)
@@ -42,6 +49,7 @@ CBotTypResult::CBotTypResult(int type, const std::string& name)
          type == CBotTypIntrinsic )
     {
         m_class = CBotClass::Find(name);
+        assert(m_class != nullptr);
         if (m_class && m_class->IsIntrinsic() ) m_type = CBotTypIntrinsic;
     }
 }
@@ -50,6 +58,7 @@ CBotTypResult::CBotTypResult(int type, CBotClass* pClass)
     : m_type(type),
       m_class(pClass)
 {
+    if (type != CBotTypNullPointer) assert(pClass != nullptr);
     if (m_class && m_class->IsIntrinsic() ) m_type = CBotTypIntrinsic;
 }
 
@@ -66,6 +75,18 @@ CBotTypResult::CBotTypResult(const CBotTypResult& typ)
       m_class(typ.m_class),
       m_limite(typ.m_limite)
 {
+    if (m_type == CBotTypPointer ||
+        m_type == CBotTypClass  ||
+        m_type == CBotTypIntrinsic)
+    {
+        assert(m_class != nullptr);
+    }
+
+    if (typ.Eq(CBotTypArrayPointer) ||
+        typ.Eq(CBotTypArrayBody))
+    {
+        assert(typ.m_elementType);
+    }
 
     if ( typ.m_elementType )
         m_elementType = std::make_unique<CBotTypResult>(*typ.m_elementType);
@@ -123,6 +144,7 @@ bool CBotTypResult::Compare(const CBotTypResult& typ) const
          m_type == CBotTypClass   ||
          m_type == CBotTypIntrinsic )
     {
+        assert(m_class != nullptr && typ.m_class != nullptr);
         return m_class == typ.m_class;
     }
 
@@ -139,6 +161,19 @@ CBotTypResult& CBotTypResult::operator=(const CBotTypResult& src)
     m_type = src.m_type;
     m_limite = src.m_limite;
     m_class = src.m_class;
+    if (m_type == CBotTypPointer ||
+        m_type == CBotTypClass  ||
+        m_type == CBotTypIntrinsic)
+    {
+        assert(m_class != nullptr);
+    }
+
+    if (src.Eq(CBotTypArrayPointer) ||
+        src.Eq(CBotTypArrayBody))
+    {
+        assert(src.m_elementType);
+    }
+
     if ( src.m_elementType )
     {
         m_elementType = std::make_unique<CBotTypResult>(*src.m_elementType);

--- a/CBot/src/CBot/CBotTypResult.cpp
+++ b/CBot/src/CBot/CBotTypResult.cpp
@@ -41,19 +41,6 @@ CBotTypResult::CBotTypResult(int type)
     assert( type != CBotTypClass );
 }
 
-CBotTypResult::CBotTypResult(int type, const std::string& name)
-    : m_type(type)
-{
-    if ( type == CBotTypPointer ||
-         type == CBotTypClass   ||
-         type == CBotTypIntrinsic )
-    {
-        m_class = CBotClass::Find(name);
-        assert(m_class != nullptr);
-        if (m_class && m_class->IsIntrinsic() ) m_type = CBotTypIntrinsic;
-    }
-}
-
 CBotTypResult::CBotTypResult(int type, CBotClass* pClass)
     : m_type(type),
       m_class(pClass)

--- a/CBot/src/CBot/CBotTypResult.h
+++ b/CBot/src/CBot/CBotTypResult.h
@@ -55,19 +55,6 @@ public:
     CBotTypResult(int type);
 
     /**
-     * \brief Constructor for pointer types and intrinsic classes
-     *
-     * This is equivalent to calling:
-     * \code
-     * CBotTypResult(type, CBotClass::Find(name))
-     * \endcode
-     *
-     * \param type type of created result, see ::CBotType
-     * \param name name of the class
-     */
-    CBotTypResult(int type, const std::string& name);
-
-    /**
      * \brief Constructor for instance of a class
      * \param type type of created result, see ::CBotType
      * \param pClass class type

--- a/CBot/src/CBot/CBotUtils.cpp
+++ b/CBot/src/CBot/CBotUtils.cpp
@@ -58,8 +58,6 @@ CBotVar* MakeListVars(CBotVar** ppVars, bool bSetVal)
 ////////////////////////////////////////////////////////////////////////////////
 CBotTypResult TypeParam(CBotToken* &p, CBotCStack* pile)
 {
-    CBotClass*  pClass = nullptr;
-
     switch (p->GetType())
     {
     case ID_BYTE:
@@ -95,7 +93,7 @@ CBotTypResult TypeParam(CBotToken* &p, CBotCStack* pile)
         return CBotTypResult( 0 );
 
     case TokenTypVar:
-        pClass = CBotClass::Find(p);
+        auto pClass = pile->FindClass(p->GetString());
         if ( pClass != nullptr)
         {
             p = p->GetNext();

--- a/CBot/src/CBot/CBotVar/CBotVar.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVar.cpp
@@ -849,6 +849,11 @@ CBotVar::operator uint32_t()
     return GetValChar();
 }
 
+CBotVar::operator char32_t()
+{
+    return GetValChar();
+}
+
 CBotVar::operator int()
 {
     return GetValInt();
@@ -890,6 +895,11 @@ void CBotVar::operator=(short x)
 }
 
 void CBotVar::operator=(uint32_t x)
+{
+    SetValChar(x);
+}
+
+void CBotVar::operator=(char32_t x)
 {
     SetValChar(x);
 }

--- a/CBot/src/CBot/CBotVar/CBotVar.h
+++ b/CBot/src/CBot/CBotVar/CBotVar.h
@@ -437,6 +437,7 @@ public:
     operator signed char();
     operator short();
     operator uint32_t();
+    operator char32_t();
     operator int();
     operator long();
     operator float();
@@ -446,6 +447,7 @@ public:
     void operator=(signed char x);
     void operator=(short x);
     void operator=(uint32_t x);
+    void operator=(char32_t x);
     void operator=(int x);
     void operator=(long x);
     void operator=(float x);

--- a/CBot/src/CBot/CBotVar/CBotVarArray.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarArray.cpp
@@ -93,7 +93,7 @@ CBotVarSPtr CBotVarArray::GetPointer()
 
 bool CBotVarArray::PointerIsUnique() const
 {
-    return m_pInstance.unique();
+    return m_pInstance.use_count() == 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/CBot/src/CBot/CBotVar/CBotVarArray.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarArray.cpp
@@ -127,7 +127,7 @@ std::string CBotVarArray::GetValString() const
 bool CBotVarArray::Save1State(std::ostream &ostr, CBotContext& context)
 {
     if (!WriteType(ostr, m_type)) return false;
-    return WriteVarList(ostr, m_pInstance.get(), context);   // saves the instance that manages the table
+    return WriteVarListAsArray(ostr, m_pInstance.get(), context); // saves the instance that manages the table
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotVar/CBotVarArray.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarArray.cpp
@@ -127,7 +127,13 @@ std::string CBotVarArray::GetValString() const
 bool CBotVarArray::Save1State(std::ostream &ostr, CBotContext& context)
 {
     if (!WriteType(ostr, m_type)) return false;
-    return WriteVarListAsArray(ostr, m_pInstance.get(), context); // saves the instance that manages the table
+
+    if (!m_pInstance) return WriteWord(ostr, 0); // save nullptr
+
+    // save the instance
+    if (!m_pInstance->Save0State(ostr)) return false; // common header
+    if (!m_pInstance->Save1State(ostr, context)) return false; // saves the data or reference
+    return true;
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotVar/CBotVarArray.h
+++ b/CBot/src/CBot/CBotVar/CBotVarArray.h
@@ -41,8 +41,9 @@ public:
      */
     ~CBotVarArray();
 
-    void SetPointer(CBotVar* p) override;
-    CBotVarClass* GetPointer() override;
+    void SetPointer(const CBotVarSPtr& p) override;
+    CBotVarSPtr GetPointer() override;
+    bool PointerIsUnique() const override;
 
     void Copy(CBotVar* pSrc, bool bName = true) override;
 
@@ -51,11 +52,11 @@ public:
 
     std::string GetValString() const override;
 
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
 private:
     //! Array data
-    CBotVarClass* m_pInstance;
+    CBotVarSPtr m_pInstance;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotVar/CBotVarBoolean.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarBoolean.cpp
@@ -40,7 +40,7 @@ void CBotVarBoolean::Not()
     SetValInt(!GetValInt());
 }
 
-bool CBotVarBoolean::Save1State(std::ostream &ostr)
+bool CBotVarBoolean::Save1State(std::ostream &ostr, CBotContext& context)
 {
     return WriteByte(ostr, m_val);                          // the value of the variable
 }

--- a/CBot/src/CBot/CBotVar/CBotVarBoolean.h
+++ b/CBot/src/CBot/CBotVar/CBotVarBoolean.h
@@ -37,7 +37,7 @@ public:
     void XOr(CBotVar* left, CBotVar* right) override;
     void Not() override;
 
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotVar/CBotVarByte.h
+++ b/CBot/src/CBot/CBotVar/CBotVarByte.h
@@ -37,7 +37,7 @@ public:
         SetValByte(static_cast<unsigned char>(left->GetValByte()) >> right->GetValInt());
     }
 
-    bool Save1State(std::ostream &ostr) override
+    bool Save1State(std::ostream &ostr, CBotContext& context) override
     {
         return WriteByte(ostr, m_val);
     }

--- a/CBot/src/CBot/CBotVar/CBotVarChar.h
+++ b/CBot/src/CBot/CBotVar/CBotVarChar.h
@@ -51,7 +51,7 @@ public:
         SetValChar(left->GetValChar() >> right->GetValInt());
     }
 
-    bool Save1State(std::ostream &ostr) override
+    bool Save1State(std::ostream &ostr, CBotContext& context) override
     {
         return WriteUInt32(ostr, m_val);
     }

--- a/CBot/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.cpp
@@ -440,20 +440,22 @@ bool CBotVarClass::Save1State(std::ostream &ostr, CBotContext& context)
     auto pClass = m_type.GetClass();
     if (pClass != nullptr && pClass->IsIntrinsic())
     {
-        if (!WriteLong(ostr, 0)) return false;
+        if (!WriteInt(ostr, /*isExisting*/ 0)) return false;
+        if (!WriteInt(ostr, /*id*/ 0)) return false;
     }
     else
     {
-        auto pos = context.FindInstance(this);
-        if (pos == -1)
+        int id = context.FindInstance(this);
+        if (id == -1)
         {
-            // 0 to mark the instance as saved at this position
-            if (!WriteLong(ostr, 0)) return false;
-            context.DeclareInstance(ostr.tellp(), this);
+            if (!WriteInt(ostr, /*isExisting*/ 0)) return false;
+            id = context.DeclareInstance(this);
+            if (!WriteInt(ostr, id)) return false;
         }
-        else // save only the stream position of the already saved instance
+        else // save only the id of the already saved instance
         {
-            return WriteLong(ostr, pos);
+            if (!WriteInt(ostr, /*isExisting*/ 1)) return false;
+            return WriteInt(ostr, id);
         }
     }
 

--- a/CBot/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.cpp
@@ -440,22 +440,19 @@ bool CBotVarClass::Save1State(std::ostream &ostr, CBotContext& context)
     auto pClass = m_type.GetClass();
     if (pClass != nullptr && pClass->IsIntrinsic())
     {
-        if (!WriteInt(ostr, /*isExisting*/ 0)) return false;
-        if (!WriteInt(ostr, /*id*/ 0)) return false;
+        if (!WriteInt(ostr, 0)) return false; // save the object
     }
     else
     {
         int id = context.FindInstance(this);
         if (id == -1)
         {
-            if (!WriteInt(ostr, /*isExisting*/ 0)) return false;
-            id = context.DeclareInstance(this);
-            if (!WriteInt(ostr, id)) return false;
+            if (!WriteInt(ostr, 0)) return false; // save the object
+            context.DeclareInstance(this); // create unique 'id' before saving fields
         }
         else // save only the id of the already saved instance
         {
-            if (!WriteInt(ostr, /*isExisting*/ 1)) return false;
-            return WriteInt(ostr, id);
+            return WriteInt(ostr, id); // save the reference
         }
     }
 

--- a/CBot/src/CBot/CBotVar/CBotVarClass.h
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.h
@@ -21,8 +21,6 @@
 
 #include "CBot/CBotVar/CBotVar.h"
 
-#include <set>
-
 namespace CBot
 {
 
@@ -54,40 +52,13 @@ public:
     CBotVar* GetItemList() override;
     std::string GetValString() const override;
 
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
-    void Update(void* pUser) override;
+    void Update() override;
+    void SetUserPointer(std::unique_ptr<CBotUserPointer> user) override;
+    const std::unique_ptr<CBotUserPointer>& GetUserPointer() override;
 
-    //! \name Reference counter
-    //@{
-
-    /**
-     * \brief Increment reference counter
-     */
-    void IncrementUse();
-
-    /**
-     * \brief Decrement reference counter
-     */
-    void DecrementUse();
-
-    //@}
-
-    CBotVarClass* GetPointer() override;
-
-    //! \name Unique instance identifier
-    //@{
-
-    void SetIdent(long n) override;
-
-    /*!
-     * \brief Finds a class instance by unique identifier
-     * \param id Identifier to find
-     * \return Found class instance
-     */
-    static CBotVarClass* Find(long id);
-
-    //@}
+    CBotVarSPtr GetPointer() override;
 
     bool Eq(CBotVar* left, CBotVar* right) override;
     bool Ne(CBotVar* left, CBotVar* right) override;
@@ -95,18 +66,19 @@ public:
     void ConstructorSet() override;
 
 private:
-    //! List of all class instances - first
-    static std::set<CBotVarClass*> m_instances;
+    void CallDestructor(); //TODO
+
+private:
     //! Class definition
     CBotClass* m_pClass;
     //! Class members
     CBotVar* m_pVar;
-    //! Reference counter
-    int m_CptUse;
-    //! Identifier (unique) of an instance
-    long m_ItemIdent;
+    //! Weak pointer to self
+    std::weak_ptr<CBotVar> m_weakPtr;
     //! Set after constructor is called, allows destructor to be called
     bool m_bConstructor;
+
+    std::unique_ptr<CBotUserPointer> m_userPtr;
 
     friend class CBotVar;
     friend class CBotVarPointer;

--- a/CBot/src/CBot/CBotVar/CBotVarDouble.h
+++ b/CBot/src/CBot/CBotVar/CBotVarDouble.h
@@ -32,7 +32,7 @@ class CBotVarDouble : public CBotVarNumber<double, CBotTypDouble>
 public:
     CBotVarDouble(const CBotToken &name) : CBotVarNumber(name) {}
 
-    bool Save1State(std::ostream &ostr) override
+    bool Save1State(std::ostream &ostr, CBotContext& context) override
     {
         return WriteDouble(ostr, m_val);
     }

--- a/CBot/src/CBot/CBotVar/CBotVarFloat.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarFloat.cpp
@@ -22,7 +22,7 @@
 namespace CBot
 {
 
-bool CBotVarFloat::Save1State(std::ostream &ostr)
+bool CBotVarFloat::Save1State(std::ostream &ostr, CBotContext& context)
 {
     return WriteFloat(ostr, m_val); // the value of the variable
 }

--- a/CBot/src/CBot/CBotVar/CBotVarFloat.h
+++ b/CBot/src/CBot/CBotVar/CBotVarFloat.h
@@ -32,7 +32,7 @@ class CBotVarFloat : public CBotVarNumber<float, CBotTypFloat>
 public:
     CBotVarFloat(const CBotToken &name) : CBotVarNumber(name) {}
 
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/CBotVar/CBotVarInt.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarInt.cpp
@@ -80,7 +80,7 @@ bool CBotVarInt::Save0State(std::ostream &ostr)
     return CBotVar::Save0State(ostr);
 }
 
-bool CBotVarInt::Save1State(std::ostream &ostr)
+bool CBotVarInt::Save1State(std::ostream &ostr, CBotContext& context)
 {
     return WriteInt(ostr, m_val);
 }

--- a/CBot/src/CBot/CBotVar/CBotVarInt.h
+++ b/CBot/src/CBot/CBotVar/CBotVarInt.h
@@ -45,7 +45,7 @@ public:
     void SR(CBotVar* left, CBotVar* right) override;
 
     bool Save0State(std::ostream &ostr) override;
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
 protected:
 

--- a/CBot/src/CBot/CBotVar/CBotVarLong.h
+++ b/CBot/src/CBot/CBotVar/CBotVarLong.h
@@ -37,7 +37,7 @@ public:
         SetValLong(static_cast<unsigned long>(left->GetValLong()) >> right->GetValInt());
     }
 
-    bool Save1State(std::ostream &ostr) override
+    bool Save1State(std::ostream &ostr, CBotContext& context) override
     {
         return WriteLong(ostr, m_val);
     }

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
@@ -173,8 +173,8 @@ bool CBotVarPointer::Save1State(std::ostream &ostr, CBotContext& context)
         if (!WriteString(ostr, "")) return false;
     }
 
-    // also saves the proceedings copies
-    return WriteVarList(ostr, m_pVarClass.get(), context);
+    // save the instance
+    return WriteVarListAsArray(ostr, m_pVarClass.get(), context);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
@@ -145,7 +145,7 @@ CBotVarSPtr CBotVarPointer::GetPointer()
 
 bool CBotVarPointer::PointerIsUnique() const
 {
-    return m_pVarClass.unique();
+    return m_pVarClass.use_count() == 1;
 }
 
 void CBotVarPointer::SetClass(CBotClass* pClass)

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
@@ -173,8 +173,12 @@ bool CBotVarPointer::Save1State(std::ostream &ostr, CBotContext& context)
         if (!WriteString(ostr, "")) return false;
     }
 
+    if (!m_pVarClass) return WriteWord(ostr, 0); // save nullptr
+
     // save the instance
-    return WriteVarListAsArray(ostr, m_pVarClass.get(), context);
+    if (!m_pVarClass->Save0State(ostr)) return false; // common header
+    if (!m_pVarClass->Save1State(ostr, context)) return false; // saves the data or reference
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.h
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.h
@@ -49,28 +49,24 @@ public:
     CBotVar* GetItemList() override;
     std::string GetValString() const override;
 
-    void SetPointer(CBotVar* p) override;
-    CBotVarClass* GetPointer() override;
-
-    void SetIdent(long n) override;
-    /**
-     * \brief Returns the unique instance identifier
-     * \see SetIdent()
-     */
-    long GetIdent();
+    void SetPointer(const CBotVarSPtr& p) override;
+    CBotVarSPtr GetPointer() override;
+    bool PointerIsUnique() const override;
 
     void ConstructorSet() override;
 
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
-    void Update(void* pUser) override;
+    void Update() override;
+    void SetUserPointer(std::unique_ptr<CBotUserPointer> user) override;
+    const std::unique_ptr<CBotUserPointer>& GetUserPointer() override;
 
     bool Eq(CBotVar* left, CBotVar* right) override;
     bool Ne(CBotVar* left, CBotVar* right) override;
 
 private:
     //! Class pointed to
-    CBotVarClass* m_pVarClass;
+    CBotVarSPtr m_pVarClass;
     //! Class type
     CBotClass* m_pClass;
     friend class CBotVar;

--- a/CBot/src/CBot/CBotVar/CBotVarShort.h
+++ b/CBot/src/CBot/CBotVar/CBotVarShort.h
@@ -37,7 +37,7 @@ public:
         SetValShort(static_cast<unsigned short>(left->GetValShort()) >> right->GetValInt());
     }
 
-    bool Save1State(std::ostream &ostr) override
+    bool Save1State(std::ostream &ostr, CBotContext& context) override
     {
         return WriteShort(ostr, m_val);
     }

--- a/CBot/src/CBot/CBotVar/CBotVarString.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarString.cpp
@@ -37,7 +37,7 @@ bool CBotVarString::Ne(CBotVar* left, CBotVar* right)
     return left->GetValString() != right->GetValString();
 }
 
-bool CBotVarString::Save1State(std::ostream &ostr)
+bool CBotVarString::Save1State(std::ostream &ostr, CBotContext& context)
 {
     return WriteString(ostr, m_val);
 }

--- a/CBot/src/CBot/CBotVar/CBotVarString.h
+++ b/CBot/src/CBot/CBotVar/CBotVarString.h
@@ -63,7 +63,7 @@ public:
     bool Eq(CBotVar* left, CBotVar* right) override;
     bool Ne(CBotVar* left, CBotVar* right) override;
 
-    bool Save1State(std::ostream &ostr) override;
+    bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
 private:
     template<typename T>

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#include "CBot/context/cbot_context.h"
+
+namespace CBot
+{
+
+CBotContextSPtr CBotContext::CreateGlobalContext()
+{
+    auto newContext = std::shared_ptr<CBotContext>(new CBotContext);
+
+    return newContext;
+}
+
+CBotContextSPtr CBotContext::Create(const CBotContextSPtr& outer)
+{
+    auto newContext = std::shared_ptr<CBotContext>(new CBotContext(outer));
+
+    return newContext;
+}
+
+CBotContext::CBotContext() :
+    std::enable_shared_from_this<CBotContext>(),
+    m_outerContext(nullptr),
+    m_globalData(std::make_shared<CBotContext::GlobalData>())
+{
+}
+
+CBotContext::CBotContext(const CBotContextSPtr& outer) :
+    std::enable_shared_from_this<CBotContext>(),
+    m_outerContext(outer),
+    m_globalData(outer->m_globalData)
+{
+}
+
+CBotContext::~CBotContext()
+{
+}
+
+void CBotContext::ClearInstanceList()
+{
+    m_globalData->m_instances.clear();
+}
+
+void CBotContext::DeclareInstance(long pos, CBotVar* var)
+{
+    m_globalData->m_instances[pos] = var;
+}
+
+CBotVar* CBotContext::FindInstance(long pos) const
+{
+    auto it = m_globalData->m_instances.find(pos);
+    if (it != m_globalData->m_instances.end()) return it->second;
+    return nullptr;
+}
+
+long CBotContext::FindInstance(CBotVar* var) const
+{
+    for (const auto& item : m_globalData->m_instances)
+        if (item.second == var) return item.first;
+    return -1;
+}
+
+} // namespace CBot

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -19,8 +19,6 @@
 
 #include "CBot/context/cbot_context.h"
 
-#include "CBot/stdlib/stdlib_public.h"
-
 namespace CBot
 {
 
@@ -28,6 +26,7 @@ CBotContextSPtr CBotContext::CreateGlobalContext()
 {
     auto newContext = std::shared_ptr<CBotContext>(new CBotContext);
     InitErrorConstants(newContext);
+    InitStringFunctions(newContext);
     InitMathLibrary(newContext);
 
     return newContext;
@@ -37,6 +36,7 @@ CBotContextSPtr CBotContext::Create(const CBotContextSPtr& outer)
 {
     auto newContext = std::shared_ptr<CBotContext>(new CBotContext(outer));
     InitErrorConstants(newContext);
+    InitStringFunctions(newContext);
     InitMathLibrary(newContext);
 
     return newContext;
@@ -96,6 +96,18 @@ const CBotVarUPtr& CBotContext::GetDefinedConstant(const std::string& name)
     if (!m_outerContext || m_listConstant.IsDefinedConstant(name))
         return m_listConstant.GetDefinedConstant(name);
     return m_outerContext->GetDefinedConstant(name);
+}
+
+void CBotContext::SetFileAccessHandler(std::unique_ptr<CBotFileAccessHandler> fileHandler)
+{
+    if (m_globalData->m_fileHandler) return; // already set
+
+    m_globalData->m_fileHandler = std::move(fileHandler);
+}
+
+CBotFileAccessHandler* CBotContext::GetFileAccessHandler() const
+{
+    return m_globalData->m_fileHandler.get();
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -21,6 +21,7 @@
 
 #include "CBot/CBotClass.h"
 
+#include <algorithm>
 #include <cassert>
 
 namespace CBot
@@ -176,6 +177,22 @@ void CBotContext::SetFileAccessHandler(std::unique_ptr<CBotFileAccessHandler> fi
 CBotFileAccessHandler* CBotContext::GetFileAccessHandler() const
 {
     return m_globalData->m_fileHandler.get();
+}
+
+const std::list<CBotFunction*>& CBotContext::GetPublicFunctions() const
+{
+    return m_functions;
+}
+
+void CBotContext::AddPublicFunction(CBotFunction* func)
+{
+    m_functions.push_back(func);
+}
+
+void CBotContext::RemovePublicFunction(CBotFunction* func)
+{
+    auto it = std::find_if(m_functions.begin(), m_functions.end(), [&func](auto x) { return x == func; });
+    if (it != m_functions.end()) m_functions.erase(it);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -19,12 +19,16 @@
 
 #include "CBot/context/cbot_context.h"
 
+#include "CBot/stdlib/stdlib_public.h"
+
 namespace CBot
 {
 
 CBotContextSPtr CBotContext::CreateGlobalContext()
 {
     auto newContext = std::shared_ptr<CBotContext>(new CBotContext);
+    InitErrorConstants(newContext);
+    InitMathLibrary(newContext);
 
     return newContext;
 }
@@ -32,6 +36,8 @@ CBotContextSPtr CBotContext::CreateGlobalContext()
 CBotContextSPtr CBotContext::Create(const CBotContextSPtr& outer)
 {
     auto newContext = std::shared_ptr<CBotContext>(new CBotContext(outer));
+    InitErrorConstants(newContext);
+    InitMathLibrary(newContext);
 
     return newContext;
 }
@@ -76,6 +82,20 @@ long CBotContext::FindInstance(CBotVar* var) const
     for (const auto& item : m_globalData->m_instances)
         if (item.second == var) return item.first;
     return -1;
+}
+
+bool CBotContext::IsDefinedConstant(const std::string& name) const
+{
+    if (!m_listConstant.IsDefinedConstant(name))
+        return m_outerContext && m_outerContext->IsDefinedConstant(name);
+    return true;
+}
+
+const CBotVarUPtr& CBotContext::GetDefinedConstant(const std::string& name)
+{
+    if (!m_outerContext || m_listConstant.IsDefinedConstant(name))
+        return m_listConstant.GetDefinedConstant(name);
+    return m_outerContext->GetDefinedConstant(name);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -30,10 +30,10 @@ namespace CBot
 CBotContextSPtr CBotContext::CreateGlobalContext()
 {
     auto newContext = std::shared_ptr<CBotContext>(new CBotContext);
-    InitErrorConstants(newContext);
-    InitFileIOLibrary(newContext);
-    InitStringFunctions(newContext);
-    InitMathLibrary(newContext);
+    InitErrorConstants(*newContext);
+    InitFileIOLibrary(*newContext);
+    InitStringFunctions(*newContext);
+    InitMathLibrary(*newContext);
 
     return newContext;
 }
@@ -41,9 +41,9 @@ CBotContextSPtr CBotContext::CreateGlobalContext()
 CBotContextSPtr CBotContext::Create(const CBotContextSPtr& outer)
 {
     auto newContext = std::shared_ptr<CBotContext>(new CBotContext(outer));
-    InitErrorConstants(newContext);
-    InitStringFunctions(newContext);
-    InitMathLibrary(newContext);
+    InitErrorConstants(*newContext);
+    InitStringFunctions(*newContext);
+    InitMathLibrary(*newContext);
 
     return newContext;
 }

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -87,8 +87,7 @@ CBotClass* CBotContext::CreateClass(const std::string& name, CBotClass* parent, 
 {
     if (FindClass(name) != nullptr) return nullptr;
     auto& newClass = m_classList[name];
-    newClass.reset(CBotClass::Create(name, parent, intrinsic));
-    newClass->SetContext( shared_from_this() );
+    newClass.reset(CBotClass::Create(name, parent, shared_from_this(), intrinsic));
     return newClass.get();
 }
 

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -69,11 +69,20 @@ CBotContext::~CBotContext()
 void CBotContext::ClearInstanceList()
 {
     m_globalData->m_instances.clear();
+    m_globalData->m_next = 1;
 }
 
-void CBotContext::DeclareInstance(long pos, CBotVar* var)
+int CBotContext::DeclareInstance(CBotVar* var)
 {
-    m_globalData->m_instances[pos] = var;
+    int id = m_globalData->m_next++;
+    m_globalData->m_instances[id] = var;
+    return id;
+}
+
+void CBotContext::DeclareInstance(int id, CBotVar* var)
+{
+    assert(m_globalData->m_next == 1);
+    m_globalData->m_instances[id] = var;
 }
 
 CBotClass* CBotContext::FindClass(const std::string& name) const
@@ -138,14 +147,14 @@ bool CBotContext::ReadStaticState(std::istream& istr, CBotContext& context)
     return true;
 }
 
-CBotVar* CBotContext::FindInstance(long pos) const
+CBotVar* CBotContext::FindInstance(int pos) const
 {
     auto it = m_globalData->m_instances.find(pos);
     if (it != m_globalData->m_instances.end()) return it->second;
     return nullptr;
 }
 
-long CBotContext::FindInstance(CBotVar* var) const
+int CBotContext::FindInstance(CBotVar* var) const
 {
     for (const auto& item : m_globalData->m_instances)
         if (item.second == var) return item.first;

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -117,7 +117,7 @@ bool CBotContext::WriteStaticState(std::ostream& ostr) const
     return true;
 }
 
-bool CBotContext::ReadStaticState(std::istream& istr, CBotContext& context)
+bool CBotContext::ReadStaticState(std::istream& istr)
 {
     unsigned short w;
     while (true)
@@ -132,9 +132,9 @@ bool CBotContext::ReadStaticState(std::istream& istr, CBotContext& context)
         std::string className;
         if (!ReadString(istr, className)) return false;
         CBotClass* pClass = nullptr;
-        auto it = context.m_classList.find(className);
-        pClass = it != context.m_classList.end() ? it->second.get() : nullptr;
-        if (!CBotClass::RestoreStaticVars(istr, pClass, context)) return false;
+        auto it = m_classList.find(className);
+        pClass = it != m_classList.end() ? it->second.get() : nullptr;
+        if (!CBotClass::RestoreStaticVars(istr, pClass, *this)) return false;
     }
     if (!ReadWord(istr, w)) return false;
     if (w != 0) return false; // currently unused flag should read 0

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -79,12 +79,6 @@ int CBotContext::DeclareInstance(CBotVar* var)
     return id;
 }
 
-void CBotContext::DeclareInstance(int id, CBotVar* var)
-{
-    assert(m_globalData->m_next == 1);
-    m_globalData->m_instances[id] = var;
-}
-
 CBotClass* CBotContext::FindClass(const std::string& name) const
 {
     auto it = m_classList.find(name);

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+namespace CBot
+{
+class CBotContext;
+class CBotVar;
+
+using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
+
+class CBotContext :
+    public std::enable_shared_from_this<CBotContext>
+{
+private:
+    CBotContext();
+
+    CBotContext(const CBotContextSPtr& outer);
+
+public:
+    [[nodiscard]] static CBotContextSPtr CreateGlobalContext();
+
+    [[nodiscard]] static CBotContextSPtr Create(const CBotContextSPtr& outer);
+
+    /**
+     * \brief Destructor
+     */
+    virtual ~CBotContext();
+
+    /**
+     * \brief Generate unique identifier for functions, etc.
+     */
+    long GetNewUniqueID()
+    {
+        return m_globalData->m_nextUniqueID++;
+    }
+
+    long FindInstance(CBotVar* var) const;
+    CBotVar* FindInstance(long pos) const;
+    void ClearInstanceList();
+    void DeclareInstance(long pos, CBotVar* var);
+
+private:
+    CBotContextSPtr m_outerContext;
+
+    struct GlobalData
+    {
+        long m_nextUniqueID = 10000;
+        std::unordered_map<long, CBotVar*> m_instances;
+    };
+    std::shared_ptr<CBotContext::GlobalData> m_globalData;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -80,10 +80,11 @@ public:
 
     static bool ReadStaticState(std::istream& istr, CBotContext& context);
 
-    long FindInstance(CBotVar* var) const;
-    CBotVar* FindInstance(long pos) const;
+    int FindInstance(CBotVar* var) const;
+    CBotVar* FindInstance(int id) const;
     void ClearInstanceList();
-    void DeclareInstance(long pos, CBotVar* var);
+    int DeclareInstance(CBotVar* var);
+    void DeclareInstance(int id, CBotVar* var);
 
     bool IsDefinedConstant(const std::string& name) const override;
 
@@ -108,7 +109,8 @@ private:
     {
         long m_nextUniqueID = 10000;
         CBotFileAccessHandlerUPtr m_fileHandler;
-        std::unordered_map<long, CBotVar*> m_instances;
+        std::unordered_map<int, CBotVar*> m_instances;
+        int m_next = 1;
     };
     std::shared_ptr<CBotContext::GlobalData> m_globalData;
 

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -29,7 +29,9 @@
 
 namespace CBot
 {
+class CBotClass;
 class CBotContext;
+class CBotProgram;
 class CBotVar;
 
 using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
@@ -63,6 +65,16 @@ public:
         return m_globalData->m_nextUniqueID++;
     }
 
+    CBotClass* FindClass(const std::string& name) const;
+
+    CBotClass* CreateClass(const std::string& name, CBotClass* parent, bool intrinsic = false);
+
+    void FreeLock(CBotProgram* prog) const;
+
+    bool WriteStaticState(std::ostream& ostr) const;
+
+    static bool ReadStaticState(std::istream& istr, CBotContext& context);
+
     long FindInstance(CBotVar* var) const;
     CBotVar* FindInstance(long pos) const;
     void ClearInstanceList();
@@ -86,6 +98,8 @@ private:
         std::unordered_map<long, CBotVar*> m_instances;
     };
     std::shared_ptr<CBotContext::GlobalData> m_globalData;
+
+    std::unordered_map<std::string, std::unique_ptr<CBotClass>> m_classList;
 };
 
 } // namespace CBot

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "CBot/context/list_constant_interface.h"
+
 #include <memory>
 #include <unordered_map>
 
@@ -30,7 +32,8 @@ class CBotVar;
 using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
 
 class CBotContext :
-    public std::enable_shared_from_this<CBotContext>
+    public std::enable_shared_from_this<CBotContext>,
+    public CBotListConstantInterface
 {
 private:
     CBotContext();
@@ -59,6 +62,10 @@ public:
     CBotVar* FindInstance(long pos) const;
     void ClearInstanceList();
     void DeclareInstance(long pos, CBotVar* var);
+
+    bool IsDefinedConstant(const std::string& name) const override;
+
+    const CBotVarUPtr& GetDefinedConstant(const std::string& name) override;
 
 private:
     CBotContextSPtr m_outerContext;

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -24,6 +24,7 @@
 
 #include "CBot/stdlib/stdlib_public.h"
 
+#include <list>
 #include <memory>
 #include <unordered_map>
 
@@ -31,6 +32,7 @@ namespace CBot
 {
 class CBotClass;
 class CBotContext;
+class CBotFunction;
 class CBotProgram;
 class CBotVar;
 
@@ -88,8 +90,16 @@ public:
 
     void SetFileAccessHandler(CBotFileAccessHandlerUPtr fileHandler);
 
+    const std::list<CBotFunction*>& GetPublicFunctions() const;
+
+    void AddPublicFunction(CBotFunction* func);
+
+    void RemovePublicFunction(CBotFunction* func);
+
 private:
     CBotContextSPtr m_outerContext;
+
+    std::list<CBotFunction*> m_functions;
 
     struct GlobalData
     {

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -19,7 +19,10 @@
 
 #pragma once
 
+#include "CBot/context/external_call_list_interface.h"
 #include "CBot/context/list_constant_interface.h"
+
+#include "CBot/stdlib/stdlib_public.h"
 
 #include <memory>
 #include <unordered_map>
@@ -30,9 +33,11 @@ class CBotContext;
 class CBotVar;
 
 using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
+using CBotFileAccessHandlerUPtr = std::unique_ptr<CBot::CBotFileAccessHandler>;
 
 class CBotContext :
     public std::enable_shared_from_this<CBotContext>,
+    public CBotExternalCallListInterface,
     public CBotListConstantInterface
 {
 private:
@@ -67,12 +72,17 @@ public:
 
     const CBotVarUPtr& GetDefinedConstant(const std::string& name) override;
 
+    CBotFileAccessHandler* GetFileAccessHandler() const;
+
+    void SetFileAccessHandler(CBotFileAccessHandlerUPtr fileHandler);
+
 private:
     CBotContextSPtr m_outerContext;
 
     struct GlobalData
     {
         long m_nextUniqueID = 10000;
+        CBotFileAccessHandlerUPtr m_fileHandler;
         std::unordered_map<long, CBotVar*> m_instances;
     };
     std::shared_ptr<CBotContext::GlobalData> m_globalData;

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -49,6 +49,9 @@ private:
 
     CBotContext(const CBotContextSPtr& outer);
 
+    CBotContext(const CBotContext&) = delete;
+    CBotContext& operator=(const CBotContext&) = delete;
+
 public:
     [[nodiscard]] static CBotContextSPtr CreateGlobalContext();
 
@@ -57,7 +60,7 @@ public:
     /**
      * \brief Destructor
      */
-    virtual ~CBotContext();
+    ~CBotContext();
 
     /**
      * \brief Generate unique identifier for functions, etc.

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -77,8 +77,7 @@ public:
     void FreeLock(CBotProgram* prog) const;
 
     bool WriteStaticState(std::ostream& ostr) const;
-
-    static bool ReadStaticState(std::istream& istr, CBotContext& context);
+    bool ReadStaticState(std::istream& istr);
 
     int FindInstance(CBotVar* var) const;
     CBotVar* FindInstance(int id) const;

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -84,7 +84,6 @@ public:
     CBotVar* FindInstance(int id) const;
     void ClearInstanceList();
     int DeclareInstance(CBotVar* var);
-    void DeclareInstance(int id, CBotVar* var);
 
     bool IsDefinedConstant(const std::string& name) const override;
 

--- a/CBot/src/CBot/context/cbot_user_pointer.h
+++ b/CBot/src/CBot/context/cbot_user_pointer.h
@@ -25,7 +25,7 @@
 namespace CBot
 {
 
-struct CBotUserPointer
+class CBotUserPointer
 {
 public:
 

--- a/CBot/src/CBot/context/cbot_user_pointer.h
+++ b/CBot/src/CBot/context/cbot_user_pointer.h
@@ -17,20 +17,38 @@
  * along with this program. If not, see http://gnu.org/licenses
  */
 
-/*!
- * \file CBot.h
- * \brief Public interface of CBot language interpreter. CBot.h is the only file
- * that should be included by any Colobot files outside of the CBot module.
- */
+#pragma once
 
-#include "CBot/CBotFileUtils.h"
-#include "CBot/CBotClass.h"
-#include "CBot/CBotToken.h"
-#include "CBot/CBotProgram.h"
-#include "CBot/CBotTypResult.h"
 
-#include "CBot/CBotVar/CBotVar.h"
+#include <memory>
 
-#include "CBot/context/cbot_context.h"
+namespace CBot
+{
 
-#include "CBot/stdlib/stdlib_public.h"
+struct CBotUserPointer
+{
+public:
+
+    CBotUserPointer() : m_userPtr(nullptr) {}
+    CBotUserPointer(void* user) :  m_userPtr(user) {}
+
+    static std::unique_ptr<CBotUserPointer> Create()
+    {
+        return std::make_unique<CBotUserPointer>();
+    }
+
+    static std::unique_ptr<CBotUserPointer> Create(void* user)
+    {
+        return std::make_unique<CBotUserPointer>(user);
+    }
+
+    void SetPointerAs(void* user) { m_userPtr = user; }
+
+    template<typename T>
+    T* GetPointerAs() { return static_cast<T*>(m_userPtr); }
+
+private:
+    void* m_userPtr;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/context/context_observer.h
+++ b/CBot/src/CBot/context/context_observer.h
@@ -30,17 +30,14 @@ using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
 
 class CBotContextObserver
 {
-public:
-    virtual ~CBotContextObserver() {}
+protected:
+    CBotContextObserver(const CBotContextSPtr& context) : m_context(context) {}
+    ~CBotContextObserver() {}
 
+public:
     CBotContextSPtr GetContext() const
     {
         return m_context.lock();
-    }
-
-    void SetContext(const CBotContextSPtr& context)
-    {
-        if (context && !m_context.lock()) m_context = context; // only once
     }
 
 protected:

--- a/CBot/src/CBot/context/context_observer.h
+++ b/CBot/src/CBot/context/context_observer.h
@@ -17,20 +17,35 @@
  * along with this program. If not, see http://gnu.org/licenses
  */
 
-/*!
- * \file CBot.h
- * \brief Public interface of CBot language interpreter. CBot.h is the only file
- * that should be included by any Colobot files outside of the CBot module.
- */
+#pragma once
 
-#include "CBot/CBotFileUtils.h"
-#include "CBot/CBotClass.h"
-#include "CBot/CBotToken.h"
-#include "CBot/CBotProgram.h"
-#include "CBot/CBotTypResult.h"
+#include <memory>
 
-#include "CBot/CBotVar/CBotVar.h"
+namespace CBot
+{
 
-#include "CBot/context/cbot_context.h"
+class CBotContext;
 
-#include "CBot/stdlib/stdlib_public.h"
+using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
+
+class CBotContextObserver
+{
+public:
+    virtual ~CBotContextObserver() {}
+
+    CBotContextSPtr GetContext() const
+    {
+        return m_context.lock();
+    }
+
+    void SetContext(const CBotContextSPtr& context)
+    {
+        if (context && !m_context.lock()) m_context = context; // only once
+    }
+
+protected:
+
+    std::weak_ptr<CBotContext> m_context;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/context/context_owner.h
+++ b/CBot/src/CBot/context/context_owner.h
@@ -30,17 +30,14 @@ using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
 
 class CBotContextOwner
 {
-public:
-    virtual ~CBotContextOwner() {}
+protected:
+    CBotContextOwner(const CBotContextSPtr& context) : m_context(context) {}
+    ~CBotContextOwner() {}
 
+public:
     const CBotContextSPtr& GetContext() const
     {
         return m_context;
-    }
-
-    void SetContext(const CBotContextSPtr& context)
-    {
-        if (!m_context) m_context = context; // only once
     }
 
 protected:

--- a/CBot/src/CBot/context/context_owner.h
+++ b/CBot/src/CBot/context/context_owner.h
@@ -17,20 +17,35 @@
  * along with this program. If not, see http://gnu.org/licenses
  */
 
-/*!
- * \file CBot.h
- * \brief Public interface of CBot language interpreter. CBot.h is the only file
- * that should be included by any Colobot files outside of the CBot module.
- */
+#pragma once
 
-#include "CBot/CBotFileUtils.h"
-#include "CBot/CBotClass.h"
-#include "CBot/CBotToken.h"
-#include "CBot/CBotProgram.h"
-#include "CBot/CBotTypResult.h"
+#include <memory>
 
-#include "CBot/CBotVar/CBotVar.h"
+namespace CBot
+{
 
-#include "CBot/context/cbot_context.h"
+class CBotContext;
 
-#include "CBot/stdlib/stdlib_public.h"
+using CBotContextSPtr = std::shared_ptr<CBot::CBotContext>;
+
+class CBotContextOwner
+{
+public:
+    virtual ~CBotContextOwner() {}
+
+    const CBotContextSPtr& GetContext() const
+    {
+        return m_context;
+    }
+
+    void SetContext(const CBotContextSPtr& context)
+    {
+        if (!m_context) m_context = context; // only once
+    }
+
+protected:
+
+    CBotContextSPtr m_context;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/context/external_call_list_interface.h
+++ b/CBot/src/CBot/context/external_call_list_interface.h
@@ -29,15 +29,16 @@ namespace CBot
 
 class CBotExternalCallListInterface
 {
-public:
+protected:
     CBotExternalCallListInterface()
     {
     }
 
-    virtual ~CBotExternalCallListInterface()
+    ~CBotExternalCallListInterface()
     {
     }
 
+public:
     /**
      * \brief Add a function that can be called from CBOT
      *
@@ -136,7 +137,7 @@ public:
         return m_externalCallList.SetUserPtr(pUser);
     }
 
-protected:
+private:
     CBotExternalCallList m_externalCallList;
 };
 

--- a/CBot/src/CBot/context/external_call_list_interface.h
+++ b/CBot/src/CBot/context/external_call_list_interface.h
@@ -1,0 +1,143 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+#include "CBot/CBotExternalCall.h"
+#include "CBot/CBotTypResult.h"
+
+#include <utility>
+
+namespace CBot
+{
+
+class CBotExternalCallListInterface
+{
+public:
+    CBotExternalCallListInterface()
+    {
+    }
+
+    virtual ~CBotExternalCallListInterface()
+    {
+    }
+
+    /**
+     * \brief Add a function that can be called from CBOT
+     *
+     * To define an external function, proceed as follows:
+     *
+     * 1. Define a function for compilation
+     *
+     * This function should take a list of function arguments (types only, no values!) and a user-defined void* pointer (can be passed in Compile()) as parameters, and return CBotTypResult.
+     *
+     * Usually, name of this function is prefixed with "c".
+     *
+     * The function should iterate through the provided parameter list and verify that they match.<br>
+     * If they don't, then return CBotTypResult with an appropariate error code (see ::CBotError).<br>
+     * If they do, return CBotTypResult with the function's return type
+     *
+     * \code
+     * CBotTypResult cMessage(CBotVar* &var, void* user)
+     * {
+     *     if (var == nullptr) return CBotTypResult(CBotErrLowParam); // Not enough parameters
+     *     if (var->GetType() != CBotTypString) return CBotTypResult(CBotErrBadString); // String expected
+     *
+     *     var = var->GetNext(); // Get the next parameter
+     *     if (var != nullptr) return CBotTypResult(CBotErrOverParam); // Too many parameters
+     *
+     *     return CBotTypResult(CBotTypFloat); // This function returns float (it may depend on parameters given!)
+     * }
+     * \endcode
+     *
+     * 2. Define a function for execution
+     *
+     * This function should take:
+     * * a list of parameters
+     * * pointer to a result variable (a variable of type given at compilation time will be provided)
+     * * pointer to an exception variable
+     * * user-defined pointer (can be passed in Run())
+     *
+     * This function returns true if execution of this function is finished, or false to suspend the program and call this function again on next Run() cycle.
+     *
+     * Usually, execution functions are prefixed with "r".
+     *
+     * \code
+     * bool rMessage(CBotVar* var, CBotVar* result, int& exception, void* user)
+     * {
+     *     std::string message = var->GetValString();
+     *     std::cout << message << std::endl;
+     *
+     *     result->SetValInt(0); set the return value
+     *     return true; // Execution finished
+     * }
+     * \endcode
+     *
+     * 3. Call AddFunction() to register the function in the list
+     *
+     * \code
+     * AddFunction("message", rMessage, cMessage);
+     * \endcode
+     *
+     * For more sophisticated examples, see the Colobot source code, mainly the src/script/scriptfunc.cpp file
+     *
+     * \param name Name of the function
+     * \param rExec Execution function
+     * \param rCompile Compilation function
+     * \return false if there was an error, otherwise true
+     */
+    template<typename R = DefaultRuntimeFunc, typename C = DefaultCompileFunc>
+    bool AddFunction(const std::string& name, R rExec, C cCompile)
+    {
+        return m_externalCallList.AddFunction(name, rExec, cCompile);
+    }
+
+    template<typename... Args>
+    CBotTypResult CompileCall(Args&&... args)
+    {
+        return m_externalCallList.CompileCall(std::forward<Args>(args)...);
+    }
+
+    bool CheckCall(const std::string& name)
+    {
+        return m_externalCallList.CheckCall(name);
+    }
+
+    template<typename... Args>
+    int DoCall(Args&&... args)
+    {
+        return m_externalCallList.DoCall(std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    bool RestoreCall(Args&&... args)
+    {
+        return m_externalCallList.RestoreCall(std::forward<Args>(args)...);
+    }
+
+    void SetUserPtr(void* pUser)
+    {
+        return m_externalCallList.SetUserPtr(pUser);
+    }
+
+protected:
+    CBotExternalCallList m_externalCallList;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/context/list_constant.cpp
+++ b/CBot/src/CBot/context/list_constant.cpp
@@ -67,7 +67,7 @@ bool CBotListConstant::AddConstant<float>(const std::string& name, const float& 
 }
 
 template<>
-bool CBotListConstant::AddConstant<const std::string>(const std::string& name, const std::string& value)
+bool CBotListConstant::AddConstant<std::string>(const std::string& name, const std::string& value)
 {
     auto& pt = m_list[name];
     if ( pt != nullptr ) return false;

--- a/CBot/src/CBot/context/list_constant.cpp
+++ b/CBot/src/CBot/context/list_constant.cpp
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#include "CBot/context/list_constant.h"
+
+#include "CBot/CBotVar/CBotVar.h"
+
+namespace CBot
+{
+
+CBotListConstant::CBotListConstant()
+{
+}
+
+CBotListConstant::~CBotListConstant()
+{
+}
+
+bool CBotListConstant::IsDefinedConstant(const std::string& name) const
+{
+    return m_list.count(name) != 0;
+}
+
+const CBotVarUPtr& CBotListConstant::GetDefinedConstant(const std::string& name)
+{
+    return m_list[name];
+}
+
+template<>
+bool CBotListConstant::AddConstant<int>(const std::string& name, const int& value)
+{
+    auto& pt = m_list[name];
+    if ( pt != nullptr ) return false;
+
+    pt.reset(CBotVar::Create("", CBotTypInt));
+    pt->SetName(name);
+    pt->SetValInt(value, name);
+    return true;
+}
+
+template<>
+bool CBotListConstant::AddConstant<float>(const std::string& name, const float& value)
+{
+    auto& pt = m_list[name];
+    if ( pt != nullptr ) return false;
+
+    pt.reset(CBotVar::Create("", CBotTypFloat));
+    pt->SetName(name);
+    *pt = value;
+    return true;
+}
+
+template<>
+bool CBotListConstant::AddConstant<const std::string>(const std::string& name, const std::string& value)
+{
+    auto& pt = m_list[name];
+    if ( pt != nullptr ) return false;
+
+    pt.reset(CBotVar::Create("", CBotTypString));
+    pt->SetName(name);
+    *pt = value;
+    return true;
+}
+
+} // namespace CBot

--- a/CBot/src/CBot/context/list_constant.h
+++ b/CBot/src/CBot/context/list_constant.h
@@ -59,6 +59,6 @@ template<>
 bool CBotListConstant::AddConstant<float>(const std::string& name, const float& value);
 
 template<>
-bool CBotListConstant::AddConstant<const std::string>(const std::string& name, const std::string& value);
+bool CBotListConstant::AddConstant<std::string>(const std::string& name, const std::string& value);
 
 } // namespace CBot

--- a/CBot/src/CBot/context/list_constant.h
+++ b/CBot/src/CBot/context/list_constant.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace CBot
+{
+
+class CBotVar;
+
+using CBotVarUPtr = std::unique_ptr<CBotVar>;
+
+class CBotListConstant
+{
+public:
+    CBotListConstant();
+
+    ~CBotListConstant();
+
+    template<typename T>
+    bool AddConstant(const std::string& name, const T& value)
+    {
+        static_assert(sizeof(T) == 0, "Only specializations of AddConstant can be used");
+        return false;
+    }
+
+    bool IsDefinedConstant(const std::string& name) const;
+
+    const CBotVarUPtr& GetDefinedConstant(const std::string& name);
+
+private:
+   std::unordered_map<std::string, CBotVarUPtr> m_list;
+};
+
+template<>
+bool CBotListConstant::AddConstant<int>(const std::string& name, const int& value);
+
+template<>
+bool CBotListConstant::AddConstant<float>(const std::string& name, const float& value);
+
+template<>
+bool CBotListConstant::AddConstant<const std::string>(const std::string& name, const std::string& value);
+
+} // namespace CBot

--- a/CBot/src/CBot/context/list_constant_interface.h
+++ b/CBot/src/CBot/context/list_constant_interface.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#pragma once
+
+#include "CBot/context/list_constant.h"
+
+namespace CBot
+{
+
+class CBotListConstantInterface
+{
+public:
+    virtual ~CBotListConstantInterface() {}
+
+    template<typename T>
+    bool AddConstant(const std::string& name, const T& value)
+    {
+        return m_listConstant.AddConstant(name, value);
+    }
+
+    virtual bool IsDefinedConstant(const std::string& name) const = 0;
+
+    virtual const CBotVarUPtr& GetDefinedConstant(const std::string& name) = 0;
+
+protected:
+   CBotListConstant m_listConstant;
+};
+
+} // namespace CBot

--- a/CBot/src/CBot/context/list_constant_interface.h
+++ b/CBot/src/CBot/context/list_constant_interface.h
@@ -26,9 +26,10 @@ namespace CBot
 
 class CBotListConstantInterface
 {
-public:
-    virtual ~CBotListConstantInterface() {}
+protected:
+    ~CBotListConstantInterface() {}
 
+public:
     template<typename T>
     bool AddConstant(const std::string& name, const T& value)
     {

--- a/CBot/src/CBot/stdlib/FileFunctions.cpp
+++ b/CBot/src/CBot/stdlib/FileFunctions.cpp
@@ -410,7 +410,7 @@ CBotTypResult cfeof (CBotVar* pThis, CBotVar* &pVar)
 
 } // namespace
 
-void InitFileIOLibrary(const std::shared_ptr<CBotContext>& context)
+void InitFileIOLibrary(CBotContext& context)
 {
     // create a class for file management
     // the use is as follows:
@@ -420,10 +420,10 @@ void InitFileIOLibrary(const std::shared_ptr<CBotContext>& context)
     // canal.close();   // close the file
 
     // create the class FILE
-    auto bc = context->FindClass("file");
+    auto bc = context.FindClass("file");
     if (bc == nullptr)
     {
-        bc = context->CreateClass("file", nullptr);
+        bc = context.CreateClass("file", nullptr);
         // adds the component ".filename"
         bc->AddItem("filename", CBotTypString);
         // adds the component ".handle"

--- a/CBot/src/CBot/stdlib/FileFunctions.cpp
+++ b/CBot/src/CBot/stdlib/FileFunctions.cpp
@@ -410,7 +410,7 @@ CBotTypResult cfeof (CBotVar* pThis, CBotVar* &pVar)
 
 } // namespace
 
-void InitFileFunctions()
+void InitFileIOLibrary(const std::shared_ptr<CBotContext>& context)
 {
     // create a class for file management
     // the use is as follows:
@@ -420,22 +420,26 @@ void InitFileFunctions()
     // canal.close();   // close the file
 
     // create the class FILE
-    CBotClass* bc = CBotClass::Create("file", nullptr);
-    // adds the component ".filename"
-    bc->AddItem("filename", CBotTypString);
-    // adds the component ".handle"
-    bc->AddItem("handle", CBotTypInt, CBotVar::ProtectionLevel::Private);
+    auto bc = context->FindClass("file");
+    if (bc == nullptr)
+    {
+        bc = context->CreateClass("file", nullptr);
+        // adds the component ".filename"
+        bc->AddItem("filename", CBotTypString);
+        // adds the component ".handle"
+        bc->AddItem("handle", CBotTypInt, CBotVar::ProtectionLevel::Private);
 
-    // define a constructor and a destructor
-    bc->AddFunction("file", rfconstruct, cfconstruct);
-    bc->AddFunction("~file", rfdestruct, nullptr);
+        // define a constructor and a destructor
+        bc->AddFunction("file", rfconstruct, cfconstruct);
+        bc->AddFunction("~file", rfdestruct, nullptr);
 
-    // end of the methods associated
-    bc->AddFunction("open", rfopen, cfopen);
-    bc->AddFunction("close", rfclose, cfclose);
-    bc->AddFunction("writeln", rfwrite, cfwrite);
-    bc->AddFunction("readln", rfread, cfread);
-    bc->AddFunction("eof", rfeof, cfeof );
+        // end of the methods associated
+        bc->AddFunction("open", rfopen, cfopen);
+        bc->AddFunction("close", rfclose, cfclose);
+        bc->AddFunction("writeln", rfwrite, cfwrite);
+        bc->AddFunction("readln", rfread, cfread);
+        bc->AddFunction("eof", rfeof, cfeof );
+    }
 
     //m_pFuncFile = new CBotProgram( );
     //std::stringArray ListFonctions;

--- a/CBot/src/CBot/stdlib/MathFunctions.cpp
+++ b/CBot/src/CBot/stdlib/MathFunctions.cpp
@@ -21,6 +21,8 @@
 
 #include "CBot/CBot.h"
 
+#include "CBot/context/cbot_context.h"
+
 #include <cmath>
 #include <cstdlib>
 
@@ -250,6 +252,29 @@ bool rIsNAN(CBotVar* var, CBotVar* result, int& exception, void* user)
 }
 
 } // namespace
+
+void InitErrorConstants(const std::shared_ptr<CBotContext>& context)
+{
+    context->AddConstant<int>("CBotErrZeroDiv",    CBotErrZeroDiv);    // division by zero
+    context->AddConstant<int>("CBotErrNotInit",    CBotErrNotInit);    // uninitialized variable
+    context->AddConstant<int>("CBotErrBadThrow",   CBotErrBadThrow);   // throw a negative value
+    context->AddConstant<int>("CBotErrNoRetVal",   CBotErrNoRetVal);   // function did not return results
+    context->AddConstant<int>("CBotErrNoRun",      CBotErrNoRun);      // active Run () without a function // TODO: Is this actually a runtime error?
+    context->AddConstant<int>("CBotErrUndefFunc",  CBotErrUndefFunc);  // Calling a function that no longer exists
+    context->AddConstant<int>("CBotErrNotClass",   CBotErrNotClass);   // Class no longer exists
+    context->AddConstant<int>("CBotErrNull",       CBotErrNull);       // Attempted to use a null pointer
+    context->AddConstant<int>("CBotErrNan",        CBotErrNan);        // Can't do operations on nan
+    context->AddConstant<int>("CBotErrOutArray",   CBotErrOutArray);   // Attempted access out of bounds of an array
+    context->AddConstant<int>("CBotErrStackOver",  CBotErrStackOver);  // Stack overflow
+    context->AddConstant<int>("CBotErrDeletedPtr", CBotErrDeletedPtr); // Attempted to use deleted object
+
+    // TODO: Check the other CBotError runtime codes to see if they should be included here too...
+}
+
+void InitMathLibrary(const std::shared_ptr<CBotContext>& context)
+{
+    context->AddConstant<float>("PI", PI);
+}
 
 void InitMathFunctions()
 {

--- a/CBot/src/CBot/stdlib/MathFunctions.cpp
+++ b/CBot/src/CBot/stdlib/MathFunctions.cpp
@@ -341,51 +341,51 @@ bool rPointConstructor(CBotVar* pThis, CBotVar* var, CBotVar* pResult, int& Exce
 
 } // namespace
 
-void InitErrorConstants(const std::shared_ptr<CBotContext>& context)
+void InitErrorConstants(CBotContext& context)
 {
-    context->AddConstant<int>("CBotErrZeroDiv",    CBotErrZeroDiv);    // division by zero
-    context->AddConstant<int>("CBotErrNotInit",    CBotErrNotInit);    // uninitialized variable
-    context->AddConstant<int>("CBotErrBadThrow",   CBotErrBadThrow);   // throw a negative value
-    context->AddConstant<int>("CBotErrNoRetVal",   CBotErrNoRetVal);   // function did not return results
-    context->AddConstant<int>("CBotErrNoRun",      CBotErrNoRun);      // active Run () without a function // TODO: Is this actually a runtime error?
-    context->AddConstant<int>("CBotErrUndefFunc",  CBotErrUndefFunc);  // Calling a function that no longer exists
-    context->AddConstant<int>("CBotErrNotClass",   CBotErrNotClass);   // Class no longer exists
-    context->AddConstant<int>("CBotErrNull",       CBotErrNull);       // Attempted to use a null pointer
-    context->AddConstant<int>("CBotErrNan",        CBotErrNan);        // Can't do operations on nan
-    context->AddConstant<int>("CBotErrOutArray",   CBotErrOutArray);   // Attempted access out of bounds of an array
-    context->AddConstant<int>("CBotErrStackOver",  CBotErrStackOver);  // Stack overflow
-    context->AddConstant<int>("CBotErrDeletedPtr", CBotErrDeletedPtr); // Attempted to use deleted object
+    context.AddConstant<int>("CBotErrZeroDiv",    CBotErrZeroDiv);    // division by zero
+    context.AddConstant<int>("CBotErrNotInit",    CBotErrNotInit);    // uninitialized variable
+    context.AddConstant<int>("CBotErrBadThrow",   CBotErrBadThrow);   // throw a negative value
+    context.AddConstant<int>("CBotErrNoRetVal",   CBotErrNoRetVal);   // function did not return results
+    context.AddConstant<int>("CBotErrNoRun",      CBotErrNoRun);      // active Run () without a function // TODO: Is this actually a runtime error?
+    context.AddConstant<int>("CBotErrUndefFunc",  CBotErrUndefFunc);  // Calling a function that no longer exists
+    context.AddConstant<int>("CBotErrNotClass",   CBotErrNotClass);   // Class no longer exists
+    context.AddConstant<int>("CBotErrNull",       CBotErrNull);       // Attempted to use a null pointer
+    context.AddConstant<int>("CBotErrNan",        CBotErrNan);        // Can't do operations on nan
+    context.AddConstant<int>("CBotErrOutArray",   CBotErrOutArray);   // Attempted access out of bounds of an array
+    context.AddConstant<int>("CBotErrStackOver",  CBotErrStackOver);  // Stack overflow
+    context.AddConstant<int>("CBotErrDeletedPtr", CBotErrDeletedPtr); // Attempted to use deleted object
 
     // TODO: Check the other CBotError runtime codes to see if they should be included here too...
 }
 
-void InitMathLibrary(const std::shared_ptr<CBotContext>& context)
+void InitMathLibrary(CBotContext& context)
 {
-    context->AddConstant<float>("PI", PI);
+    context.AddConstant<float>("PI", PI);
 
-    context->AddFunction("sin",   rSin,   cOneFloat);
-    context->AddFunction("cos",   rCos,   cOneFloat);
-    context->AddFunction("tan",   rTan,   cOneFloat);
-    context->AddFunction("asin",  raSin,  cOneFloat);
-    context->AddFunction("acos",  raCos,  cOneFloat);
-    context->AddFunction("atan",  raTan,  cOneFloat);
-    context->AddFunction("atan2", raTan2, cTwoFloat);
-    context->AddFunction("sqrt",  rSqrt,  cOneFloat);
-    context->AddFunction("pow",   rPow,   cTwoFloat);
-    context->AddFunction("rand",  rRand,  cNull);
-    context->AddFunction("abs",   rAbs,   cAbs);
-    context->AddFunction("floor", rFloor, cOneFloat);
-    context->AddFunction("ceil",  rCeil,  cOneFloat);
-    context->AddFunction("round", rRound, cOneFloat);
-    context->AddFunction("trunc", rTrunc, cOneFloat);
-    context->AddFunction("isnan", rIsNAN, cIsNAN);
+    context.AddFunction("sin",   rSin,   cOneFloat);
+    context.AddFunction("cos",   rCos,   cOneFloat);
+    context.AddFunction("tan",   rTan,   cOneFloat);
+    context.AddFunction("asin",  raSin,  cOneFloat);
+    context.AddFunction("acos",  raCos,  cOneFloat);
+    context.AddFunction("atan",  raTan,  cOneFloat);
+    context.AddFunction("atan2", raTan2, cTwoFloat);
+    context.AddFunction("sqrt",  rSqrt,  cOneFloat);
+    context.AddFunction("pow",   rPow,   cTwoFloat);
+    context.AddFunction("rand",  rRand,  cNull);
+    context.AddFunction("abs",   rAbs,   cAbs);
+    context.AddFunction("floor", rFloor, cOneFloat);
+    context.AddFunction("ceil",  rCeil,  cOneFloat);
+    context.AddFunction("round", rRound, cOneFloat);
+    context.AddFunction("trunc", rTrunc, cOneFloat);
+    context.AddFunction("isnan", rIsNAN, cIsNAN);
 
-    context->AddFunction("sizeof", rSizeOf, cSizeOf);
+    context.AddFunction("sizeof", rSizeOf, cSizeOf);
 
-    auto pnt = context->FindClass("point");
+    auto pnt = context.FindClass("point");
     if (pnt == nullptr)
     {
-        pnt = context->CreateClass("point", nullptr, true);  // intrinsic class
+        pnt = context.CreateClass("point", nullptr, true);  // intrinsic class
         pnt->AddItem("x", CBotTypFloat);
         pnt->AddItem("y", CBotTypFloat);
         pnt->AddItem("z", CBotTypFloat);

--- a/CBot/src/CBot/stdlib/MathFunctions.cpp
+++ b/CBot/src/CBot/stdlib/MathFunctions.cpp
@@ -19,7 +19,7 @@
 
 #include "CBot/stdlib/stdlib.h"
 
-#include "CBot/CBot.h"
+#include "CBot/CBotVar/CBotVar.h"
 
 #include "CBot/context/cbot_context.h"
 
@@ -251,6 +251,31 @@ bool rIsNAN(CBotVar* var, CBotVar* result, int& exception, void* user)
     return true;
 }
 
+CBotTypResult cSizeOf( CBotVar* &pVar, void* pUser )
+{
+    if ( pVar == nullptr ) return CBotTypResult( CBotErrLowParam );
+    if ( pVar->GetType() != CBotTypArrayPointer )
+                        return CBotTypResult( CBotErrBadParam );
+    return CBotTypResult( CBotTypInt );
+}
+
+bool rSizeOf( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
+{
+    if ( pVar == nullptr ) { ex = CBotErrLowParam; return true; }
+
+    int i = 0;
+    pVar = pVar->GetItemList();
+
+    while ( pVar != nullptr )
+    {
+        i++;
+        pVar = pVar->GetNext();
+    }
+
+    pResult->SetValInt(i);
+    return true;
+}
+
 } // namespace
 
 void InitErrorConstants(const std::shared_ptr<CBotContext>& context)
@@ -274,26 +299,25 @@ void InitErrorConstants(const std::shared_ptr<CBotContext>& context)
 void InitMathLibrary(const std::shared_ptr<CBotContext>& context)
 {
     context->AddConstant<float>("PI", PI);
-}
 
-void InitMathFunctions()
-{
-    CBotProgram::AddFunction("sin",   rSin,   cOneFloat);
-    CBotProgram::AddFunction("cos",   rCos,   cOneFloat);
-    CBotProgram::AddFunction("tan",   rTan,   cOneFloat);
-    CBotProgram::AddFunction("asin",  raSin,  cOneFloat);
-    CBotProgram::AddFunction("acos",  raCos,  cOneFloat);
-    CBotProgram::AddFunction("atan",  raTan,  cOneFloat);
-    CBotProgram::AddFunction("atan2", raTan2, cTwoFloat);
-    CBotProgram::AddFunction("sqrt",  rSqrt,  cOneFloat);
-    CBotProgram::AddFunction("pow",   rPow,   cTwoFloat);
-    CBotProgram::AddFunction("rand",  rRand,  cNull);
-    CBotProgram::AddFunction("abs",   rAbs,   cAbs);
-    CBotProgram::AddFunction("floor", rFloor, cOneFloat);
-    CBotProgram::AddFunction("ceil",  rCeil,  cOneFloat);
-    CBotProgram::AddFunction("round", rRound, cOneFloat);
-    CBotProgram::AddFunction("trunc", rTrunc, cOneFloat);
-    CBotProgram::AddFunction("isnan", rIsNAN, cIsNAN);
+    context->AddFunction("sin",   rSin,   cOneFloat);
+    context->AddFunction("cos",   rCos,   cOneFloat);
+    context->AddFunction("tan",   rTan,   cOneFloat);
+    context->AddFunction("asin",  raSin,  cOneFloat);
+    context->AddFunction("acos",  raCos,  cOneFloat);
+    context->AddFunction("atan",  raTan,  cOneFloat);
+    context->AddFunction("atan2", raTan2, cTwoFloat);
+    context->AddFunction("sqrt",  rSqrt,  cOneFloat);
+    context->AddFunction("pow",   rPow,   cTwoFloat);
+    context->AddFunction("rand",  rRand,  cNull);
+    context->AddFunction("abs",   rAbs,   cAbs);
+    context->AddFunction("floor", rFloor, cOneFloat);
+    context->AddFunction("ceil",  rCeil,  cOneFloat);
+    context->AddFunction("round", rRound, cOneFloat);
+    context->AddFunction("trunc", rTrunc, cOneFloat);
+    context->AddFunction("isnan", rIsNAN, cIsNAN);
+
+    context->AddFunction("sizeof", rSizeOf, cSizeOf);
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/stdlib/StringFunctions.cpp
+++ b/CBot/src/CBot/stdlib/StringFunctions.cpp
@@ -284,19 +284,18 @@ bool rStrLower( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
 
 } // namespace
 
-////////////////////////////////////////////////////////////////////////////////
-void InitStringFunctions()
+void InitStringFunctions(const std::shared_ptr<CBotContext>& context)
 {
-    CBotProgram::AddFunction("strlen",   rStrLen,   cIntStr );
-    CBotProgram::AddFunction("strleft",  rStrLeft,  cStrStrInt );
-    CBotProgram::AddFunction("strright", rStrRight, cStrStrInt );
-    CBotProgram::AddFunction("strmid",   rStrMid,   cStrStrIntInt );
+    context->AddFunction("strlen",   rStrLen,   cIntStr );
+    context->AddFunction("strleft",  rStrLeft,  cStrStrInt );
+    context->AddFunction("strright", rStrRight, cStrStrInt );
 
-    CBotProgram::AddFunction("strval",   rStrVal,   cFloatStr );
-    CBotProgram::AddFunction("strfind",  rStrFind,  cIntStrStr );
+    context->AddFunction("strmid",   rStrMid,   cStrStrIntInt );
+    context->AddFunction("strval",   rStrVal,   cFloatStr );
 
-    CBotProgram::AddFunction("strupper", rStrUpper, cStrStr );
-    CBotProgram::AddFunction("strlower", rStrLower, cStrStr );
+    context->AddFunction("strfind",  rStrFind,  cIntStrStr );
+    context->AddFunction("strupper", rStrUpper, cStrStr );
+    context->AddFunction("strlower", rStrLower, cStrStr );
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/stdlib/StringFunctions.cpp
+++ b/CBot/src/CBot/stdlib/StringFunctions.cpp
@@ -284,18 +284,18 @@ bool rStrLower( CBotVar* pVar, CBotVar* pResult, int& ex, void* pUser )
 
 } // namespace
 
-void InitStringFunctions(const std::shared_ptr<CBotContext>& context)
+void InitStringFunctions(CBotContext& context)
 {
-    context->AddFunction("strlen",   rStrLen,   cIntStr );
-    context->AddFunction("strleft",  rStrLeft,  cStrStrInt );
-    context->AddFunction("strright", rStrRight, cStrStrInt );
+    context.AddFunction("strlen",   rStrLen,   cIntStr );
+    context.AddFunction("strleft",  rStrLeft,  cStrStrInt );
+    context.AddFunction("strright", rStrRight, cStrStrInt );
 
-    context->AddFunction("strmid",   rStrMid,   cStrStrIntInt );
-    context->AddFunction("strval",   rStrVal,   cFloatStr );
+    context.AddFunction("strmid",   rStrMid,   cStrStrIntInt );
+    context.AddFunction("strval",   rStrVal,   cFloatStr );
 
-    context->AddFunction("strfind",  rStrFind,  cIntStrStr );
-    context->AddFunction("strupper", rStrUpper, cStrStr );
-    context->AddFunction("strlower", rStrLower, cStrStr );
+    context.AddFunction("strfind",  rStrFind,  cIntStrStr );
+    context.AddFunction("strupper", rStrUpper, cStrStr );
+    context.AddFunction("strlower", rStrLower, cStrStr );
 }
 
 } // namespace CBot

--- a/CBot/src/CBot/stdlib/stdlib.h
+++ b/CBot/src/CBot/stdlib/stdlib.h
@@ -24,6 +24,5 @@
 namespace CBot
 {
 
-void InitFileFunctions();
 
 } // namespace CBot

--- a/CBot/src/CBot/stdlib/stdlib.h
+++ b/CBot/src/CBot/stdlib/stdlib.h
@@ -24,8 +24,6 @@
 namespace CBot
 {
 
-void InitStringFunctions();
 void InitFileFunctions();
-void InitMathFunctions();
 
 } // namespace CBot

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -32,10 +32,10 @@ namespace CBot
 
 class CBotContext;
 
-void InitErrorConstants(const std::shared_ptr<CBotContext>& context);
-void InitFileIOLibrary(const std::shared_ptr<CBotContext>& context);
-void InitMathLibrary(const std::shared_ptr<CBotContext>& context);
-void InitStringFunctions(const std::shared_ptr<CBotContext>& context);
+void InitErrorConstants(CBotContext& context);
+void InitFileIOLibrary(CBotContext& context);
+void InitMathLibrary(CBotContext& context);
+void InitStringFunctions(CBotContext& context);
 
 class CBotFile
 {

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -23,8 +23,9 @@
 
 #include "CBot/context/cbot_user_pointer.h"
 
-#include <memory>
 #include <filesystem>
+#include <memory>
+#include <unordered_map>
 
 namespace CBot
 {
@@ -33,6 +34,7 @@ class CBotContext;
 
 void InitErrorConstants(const std::shared_ptr<CBotContext>& context);
 void InitMathLibrary(const std::shared_ptr<CBotContext>& context);
+void InitStringFunctions(const std::shared_ptr<CBotContext>& context);
 
 class CBotFile
 {
@@ -55,9 +57,11 @@ public:
     enum class OpenMode : char { Read = 'r', Write = 'w', Append = 'a' };
     virtual std::unique_ptr<CBotFile> OpenFile(const std::filesystem::path& filename, OpenMode mode) = 0;
     virtual bool DeleteFile(const std::filesystem::path& filename) = 0;
-};
 
-void SetFileAccessHandler(std::unique_ptr<CBotFileAccessHandler> fileHandler);
+    int m_nextFileId = 1;
+
+    std::unordered_map<int, std::unique_ptr<CBotFile>> m_files;
+};
 
 // TODO: provide default implementation of CBotFileAccessHandler
 

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -21,6 +21,8 @@
 
 #include "CBot/stdlib/Compilation.h"
 
+#include "CBot/context/cbot_user_pointer.h"
+
 #include <memory>
 #include <filesystem>
 

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -29,6 +29,11 @@
 namespace CBot
 {
 
+class CBotContext;
+
+void InitErrorConstants(const std::shared_ptr<CBotContext>& context);
+void InitMathLibrary(const std::shared_ptr<CBotContext>& context);
+
 class CBotFile
 {
 public:

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -33,6 +33,7 @@ namespace CBot
 class CBotContext;
 
 void InitErrorConstants(const std::shared_ptr<CBotContext>& context);
+void InitFileIOLibrary(const std::shared_ptr<CBotContext>& context);
 void InitMathLibrary(const std::shared_ptr<CBotContext>& context);
 void InitStringFunctions(const std::shared_ptr<CBotContext>& context);
 

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -6260,6 +6260,7 @@ std::shared_ptr<CBot::CBotContext> CRobotMain::GetCBotContextForTeam(int team)
     if (auto context = m_teamCBotContext[team].lock()) return context;
 
     auto newContext = CBot::CBotContext::Create(m_globalCBotContext);
+    CScriptFunctions::InitFunctions(newContext);
 
     m_teamCBotContext[team] = newContext;
     return newContext;

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -280,6 +280,8 @@ CRobotMain::CRobotMain()
     SelectPlayer(CPlayerProfile::GetLastName());
 
     m_globalCBotContext = CBot::CBotContext::CreateGlobalContext();
+    CScriptFunctions::InitContextGlobal(m_globalCBotContext);
+
     CScriptFunctions::Init();
 }
 
@@ -6248,6 +6250,7 @@ const std::shared_ptr<CBot::CBotContext>& CRobotMain::GetCBotContextGlobal()
     if ( !m_globalCBotContext )
     {
         m_globalCBotContext = CBot::CBotContext::CreateGlobalContext();
+        CScriptFunctions::InitContextGlobal(m_globalCBotContext);
     }
     return m_globalCBotContext;
 }

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -280,7 +280,7 @@ CRobotMain::CRobotMain()
     SelectPlayer(CPlayerProfile::GetLastName());
 
     m_globalCBotContext = CBot::CBotContext::CreateGlobalContext();
-    CScriptFunctions::InitContextGlobal(m_globalCBotContext);
+    CScriptFunctions::InitContextGlobal(*m_globalCBotContext);
 
 }
 
@@ -6283,7 +6283,7 @@ const std::shared_ptr<CBot::CBotContext>& CRobotMain::GetCBotContextGlobal()
     if ( !m_globalCBotContext )
     {
         m_globalCBotContext = CBot::CBotContext::CreateGlobalContext();
-        CScriptFunctions::InitContextGlobal(m_globalCBotContext);
+        CScriptFunctions::InitContextGlobal(*m_globalCBotContext);
     }
     return m_globalCBotContext;
 }
@@ -6292,8 +6292,8 @@ std::shared_ptr<CBot::CBotContext> CRobotMain::GetCBotContextForTeam(int team)
 {
     if (auto context = m_teamCBotContext[team].lock()) return context;
 
-    auto newContext = CBot::CBotContext::Create(m_globalCBotContext);
-    CScriptFunctions::InitFunctions(newContext);
+    auto newContext = CBot::CBotContext::Create(GetCBotContextGlobal());
+    CScriptFunctions::InitFunctions(*newContext);
 
     m_teamCBotContext[team] = newContext;
     return newContext;

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4907,7 +4907,7 @@ CObject* CRobotMain::IOReadScene(const std::filesystem::path& filename,
                     }
                 }
 
-                if (!bError && (bError = !CBot::CBotContext::ReadStaticState(istr, *m_globalCBotContext)))
+                if (!bError && (bError = !m_globalCBotContext->ReadStaticState(istr)))
                 {
                     GetLogger()->Error("global cbot context read static state failed");
                 }
@@ -4924,7 +4924,7 @@ CObject* CRobotMain::IOReadScene(const std::filesystem::path& filename,
                         if ((bError = !CBot::ReadInt(istr, team))) break;
                         auto teamContext = GetCBotContextForTeam(team);
 
-                        bError = !CBot::CBotContext::ReadStaticState(istr, *teamContext);
+                        bError = !teamContext->ReadStaticState(istr);
                     }
                     if (bError) GetLogger()->Error("team cbot context read static state failed");
                 }

--- a/colobot-base/src/level/robotmain.h
+++ b/colobot-base/src/level/robotmain.h
@@ -100,6 +100,11 @@ class COldObject;
 class CPauseManager;
 struct ActivePause;
 
+namespace CBot
+{
+class CBotContext;
+}
+
 namespace Gfx
 {
 class CEngine;
@@ -514,6 +519,10 @@ public:
     //! Returns a set of all team IDs in the current level that are still active
     std::set<int> GetAllActiveTeams();
 
+    const std::shared_ptr<CBot::CBotContext>& GetCBotContextGlobal();
+
+    std::shared_ptr<CBot::CBotContext> GetCBotContextForTeam(int team);
+
 protected:
     bool        EventFrame(const Event &event);
     bool        EventObject(const Event &event);
@@ -695,6 +704,10 @@ protected:
     bool            m_codeBattleSpectator = true;
 
     std::map<int, std::string> m_teamNames;
+
+    std::map<int, std::weak_ptr<CBot::CBotContext>> m_teamCBotContext;
+
+    std::shared_ptr<CBot::CBotContext> m_globalCBotContext;
 
     std::vector<NewScriptName> m_newScriptName;
 

--- a/colobot-base/src/script/script.cpp
+++ b/colobot-base/src/script/script.cpp
@@ -164,7 +164,9 @@ bool CScript::CheckToken()
     std::map<std::string, int> cursor1;
     std::map<std::string, int> cursor2;
 
-    auto tokens = CBot::CBotToken::CompileTokens(m_script);
+    const auto& context = m_main->GetCBotContextGlobal();
+
+    auto tokens = CBot::CBotToken::CompileTokens(m_script, *context);
     CBot::CBotToken* bt = tokens.get();
     while ( bt != nullptr )
     {
@@ -654,7 +656,9 @@ void CScript::ColorizeScript(Ui::CEdit* edit, int rangeStart, int rangeEnd)
     std::string text = edit->GetText();
     text = text.substr(rangeStart, rangeEnd-rangeStart);
 
-    auto tokens = CBot::CBotToken::CompileTokens(text.c_str());
+    const auto& context = CRobotMain::GetInstancePointer()->GetCBotContextGlobal();
+
+    auto tokens = CBot::CBotToken::CompileTokens(text.c_str(), *context);
     CBot::CBotToken* bt = tokens.get();
     while ( bt != nullptr )
     {

--- a/colobot-base/src/script/script.cpp
+++ b/colobot-base/src/script/script.cpp
@@ -242,8 +242,8 @@ bool CScript::Compile()
 
     if (m_botProg == nullptr)
     {
-        m_botProg = std::make_unique<CBot::CBotProgram>(m_object->GetBotVar());
-        m_botProg->SetContext(m_main->GetCBotContextForTeam(m_object->GetTeam()));
+        auto context = m_main->GetCBotContextForTeam(m_object->GetTeam());
+        m_botProg = std::make_unique<CBot::CBotProgram>(context, m_object->GetBotVar());
     }
 
     if ( m_botProg->Compile(m_script, functionList, this) )

--- a/colobot-base/src/script/script.cpp
+++ b/colobot-base/src/script/script.cpp
@@ -80,7 +80,6 @@ CScript::CScript(COldObject* object)
 
 CScript::~CScript()
 {
-    
 }
 
 
@@ -225,7 +224,6 @@ static bool isValidRange(const std::string& script, int cursor1, int cursor2)
 bool CScript::Compile()
 {
     std::vector<std::string> functionList;
-    std::string     p;
 
     m_error = CBot::CBotNoErr;
     m_cursor1 = 0;
@@ -243,6 +241,7 @@ bool CScript::Compile()
     if (m_botProg == nullptr)
     {
         m_botProg = std::make_unique<CBot::CBotProgram>(m_object->GetBotVar());
+        m_botProg->SetContext(m_main->GetCBotContextForTeam(m_object->GetTeam()));
     }
 
     if ( m_botProg->Compile(m_script, functionList, this) )
@@ -491,7 +490,7 @@ static void PutList(const std::string& baseName, bool bArray, CBot::CBotVar *var
     int index = 0;
     while (var != nullptr)
     {
-        var->Update(nullptr);
+        var->Update();
         CBot::CBotVar* pStatic = var->GetStaticVar();  // finds the static element
 
         std::string varName;

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -3496,93 +3496,6 @@ void CScriptFunctions::Init()
 {
     CBotProgram::Init();
 
-    for (int i = 0; i < OBJECT_MAX; i++)
-    {
-        ObjectType type = static_cast<ObjectType>(i);
-        const char* token = GetObjectName(type);
-        if (token[0] != 0)
-            CBotProgram::DefineNum(token, type);
-
-        token = GetObjectAlias(type);
-        if (token[0] != 0)
-            CBotProgram::DefineNum(token, type);
-    }
-    CBotProgram::DefineNum("Any", OBJECT_NULL);
-
-    for (int i = 0; i < static_cast<int>(TraceColor::Max); i++)
-    {
-        TraceColor color = static_cast<TraceColor>(i);
-        CBotProgram::DefineNum(TraceColorName(color).c_str(), static_cast<int>(color));
-    }
-
-    CBotProgram::DefineNum("InFront",    TMA_FFRONT);
-    CBotProgram::DefineNum("Behind",     TMA_FBACK);
-    CBotProgram::DefineNum("EnergyCell", TMA_POWER);
-
-    CBotProgram::DefineNum("DisplayError",   Ui::TT_ERROR);
-    CBotProgram::DefineNum("DisplayWarning", Ui::TT_WARNING);
-    CBotProgram::DefineNum("DisplayInfo",    Ui::TT_INFO);
-    CBotProgram::DefineNum("DisplayMessage", Ui::TT_MESSAGE);
-
-    CBotProgram::DefineNum("FilterNone",        FILTER_NONE);
-    CBotProgram::DefineNum("FilterOnlyLanding", FILTER_ONLYLANDING);
-    CBotProgram::DefineNum("FilterOnlyFlying",  FILTER_ONLYFLYING);
-    CBotProgram::DefineNum("FilterFriendly",    FILTER_FRIENDLY);
-    CBotProgram::DefineNum("FilterEnemy",       FILTER_ENEMY);
-    CBotProgram::DefineNum("FilterNeutral",     FILTER_NEUTRAL);
-
-    CBotProgram::DefineNum("DestructionNone",           static_cast<int>(DestructionType::NoEffect));
-    CBotProgram::DefineNum("DestructionExplosion",      static_cast<int>(DestructionType::Explosion));
-    CBotProgram::DefineNum("DestructionExplosionWater", static_cast<int>(DestructionType::ExplosionWater));
-    CBotProgram::DefineNum("DestructionBurn",           static_cast<int>(DestructionType::Burn));
-    CBotProgram::DefineNum("DestructionDrowned",        static_cast<int>(DestructionType::Drowned));
-
-    CBotProgram::DefineNum("ResultNotEnded",  ERR_MISSION_NOTERM);
-    CBotProgram::DefineNum("ResultLost",      INFO_LOST);
-    CBotProgram::DefineNum("ResultLostQuick", INFO_LOSTq);
-    CBotProgram::DefineNum("ResultWin",       ERR_OK);
-
-    // NOTE: The Build___ constants are for use only with getbuild() and setbuild() for MissionController, not for normal players
-    CBotProgram::DefineNum("BuildBotFactory",       BUILD_FACTORY);
-    CBotProgram::DefineNum("BuildDerrick",          BUILD_DERRICK);
-    CBotProgram::DefineNum("BuildConverter",        BUILD_CONVERT);
-    CBotProgram::DefineNum("BuildRadarStation",     BUILD_RADAR);
-    CBotProgram::DefineNum("BuildPowerPlant",       BUILD_ENERGY);
-    CBotProgram::DefineNum("BuildNuclearPlant",     BUILD_NUCLEAR);
-    CBotProgram::DefineNum("BuildPowerStation",     BUILD_STATION);
-    CBotProgram::DefineNum("BuildRepairCenter",     BUILD_REPAIR);
-    CBotProgram::DefineNum("BuildDefenseTower",     BUILD_TOWER);
-    CBotProgram::DefineNum("BuildResearchCenter",   BUILD_RESEARCH);
-    CBotProgram::DefineNum("BuildAutoLab",          BUILD_LABO);
-    CBotProgram::DefineNum("BuildPowerCaptor",      BUILD_PARA);
-    CBotProgram::DefineNum("BuildExchangePost",     BUILD_INFO);
-    CBotProgram::DefineNum("BuildVault",            BUILD_SAFE);
-    CBotProgram::DefineNum("BuildDestroyer",        BUILD_DESTROYER);
-    CBotProgram::DefineNum("FlatGround",            BUILD_GFLAT);
-    CBotProgram::DefineNum("UseFlags",              BUILD_FLAG);
-
-    CBotProgram::DefineNum("ResearchTracked",       RESEARCH_TANK);
-    CBotProgram::DefineNum("ResearchWinged",        RESEARCH_FLY);
-    CBotProgram::DefineNum("ResearchShooter",       RESEARCH_CANON);
-    CBotProgram::DefineNum("ResearchDefenseTower",  RESEARCH_TOWER);
-    CBotProgram::DefineNum("ResearchNuclearPlant",  RESEARCH_ATOMIC);
-    CBotProgram::DefineNum("ResearchThumper",       RESEARCH_THUMP);
-    CBotProgram::DefineNum("ResearchShielder",      RESEARCH_SHIELD);
-    CBotProgram::DefineNum("ResearchPhazerShooter", RESEARCH_PHAZER);
-    CBotProgram::DefineNum("ResearchLegged",        RESEARCH_iPAW);
-    CBotProgram::DefineNum("ResearchOrgaShooter",   RESEARCH_iGUN);
-    CBotProgram::DefineNum("ResearchRecycler",      RESEARCH_RECYCLER);
-    CBotProgram::DefineNum("ResearchSubber",        RESEARCH_SUBM);
-    CBotProgram::DefineNum("ResearchSniffer",       RESEARCH_SNIFFER);
-    CBotProgram::DefineNum("ResearchBuilder",       RESEARCH_BUILDER);
-    CBotProgram::DefineNum("ResearchTarget",        RESEARCH_TARGET);
-
-    CBotProgram::DefineNum("CameraDefault",         static_cast<int>(CameraView::DEFAULT));
-    CBotProgram::DefineNum("CameraOnboard",         static_cast<int>(CameraView::ONBOARD));
-    CBotProgram::DefineNum("CameraBack",            static_cast<int>(CameraView::BACK));
-
-    CBotProgram::DefineNum("PolskiPortalColobota", 1337);
-
     CBotClass* bc;
 
     const auto& context = CRobotMain::GetInstancePointer()->GetCBotContextGlobal();
@@ -3692,6 +3605,102 @@ void CScriptFunctions::Init()
     SetFileAccessHandler(std::make_unique<CBotFileAccessHandlerColobot>());
 }
 
+void CScriptFunctions::InitContextGlobal(const std::shared_ptr<CBot::CBotContext>& globalContext)
+{
+    auto AddConstant = [&globalContext](const std::string& name, int num)
+    {
+        if (!globalContext->AddConstant<int>(name, num))
+            GetLogger()->Error("Constant '%%' redefined", name);
+    };
+
+    for (int i = 0; i < OBJECT_MAX; i++)
+    {
+        ObjectType type = static_cast<ObjectType>(i);
+        const char* token = GetObjectName(type);
+        if (token[0] != 0)
+            AddConstant(token, type);
+
+        token = GetObjectAlias(type);
+        if (token[0] != 0)
+            AddConstant(token, type);
+    }
+    AddConstant("Any", OBJECT_NULL);
+
+    for (int i = 0; i < static_cast<int>(TraceColor::Max); i++)
+    {
+        TraceColor color = static_cast<TraceColor>(i);
+        AddConstant(TraceColorName(color), static_cast<int>(color));
+    }
+
+    AddConstant("InFront",    TMA_FFRONT);
+    AddConstant("Behind",     TMA_FBACK);
+    AddConstant("EnergyCell", TMA_POWER);
+
+    AddConstant("DisplayError",         Ui::TT_ERROR);
+    AddConstant("DisplayWarning",       Ui::TT_WARNING);
+    AddConstant("DisplayInfo",          Ui::TT_INFO);
+    AddConstant("DisplayMessage",       Ui::TT_MESSAGE);
+
+    AddConstant("FilterNone",               FILTER_NONE);
+    AddConstant("FilterOnlyLanding",        FILTER_ONLYLANDING);
+    AddConstant("FilterOnlyFlying",         FILTER_ONLYFLYING);
+    AddConstant("FilterFriendly",           FILTER_FRIENDLY);
+    AddConstant("FilterEnemy",              FILTER_ENEMY);
+    AddConstant("FilterNeutral",            FILTER_NEUTRAL);
+
+    AddConstant("DestructionNone",           static_cast<int>(DestructionType::NoEffect));
+    AddConstant("DestructionExplosion",      static_cast<int>(DestructionType::Explosion));
+    AddConstant("DestructionExplosionWater", static_cast<int>(DestructionType::ExplosionWater));
+    AddConstant("DestructionBurn",           static_cast<int>(DestructionType::Burn));
+    AddConstant("DestructionDrowned",        static_cast<int>(DestructionType::Drowned));
+
+    AddConstant("ResultNotEnded",       ERR_MISSION_NOTERM);
+    AddConstant("ResultLost",           INFO_LOST);
+    AddConstant("ResultLostQuick",      INFO_LOSTq);
+    AddConstant("ResultWin",            ERR_OK);
+
+    // NOTE: The Build___ constants are for use only with getbuild() and setbuild() for MissionController, not for normal players
+    AddConstant("BuildBotFactory",              BUILD_FACTORY);
+    AddConstant("BuildDerrick",                 BUILD_DERRICK);
+    AddConstant("BuildConverter",               BUILD_CONVERT);
+    AddConstant("BuildRadarStation",            BUILD_RADAR);
+    AddConstant("BuildPowerPlant",              BUILD_ENERGY);
+    AddConstant("BuildNuclearPlant",            BUILD_NUCLEAR);
+    AddConstant("BuildPowerStation",            BUILD_STATION);
+    AddConstant("BuildRepairCenter",            BUILD_REPAIR);
+    AddConstant("BuildDefenseTower",            BUILD_TOWER);
+    AddConstant("BuildResearchCenter",          BUILD_RESEARCH);
+    AddConstant("BuildAutoLab",                 BUILD_LABO);
+    AddConstant("BuildPowerCaptor",             BUILD_PARA);
+    AddConstant("BuildExchangePost",            BUILD_INFO);
+    AddConstant("BuildVault",                   BUILD_SAFE);
+    AddConstant("BuildDestroyer",               BUILD_DESTROYER);
+    AddConstant("FlatGround",                   BUILD_GFLAT);
+    AddConstant("UseFlags",                     BUILD_FLAG);
+
+    AddConstant("ResearchTracked",              RESEARCH_TANK);
+    AddConstant("ResearchWinged",               RESEARCH_FLY);
+    AddConstant("ResearchShooter",              RESEARCH_CANON);
+    AddConstant("ResearchDefenseTower",         RESEARCH_TOWER);
+    AddConstant("ResearchNuclearPlant",         RESEARCH_ATOMIC);
+    AddConstant("ResearchThumper",              RESEARCH_THUMP);
+    AddConstant("ResearchShielder",             RESEARCH_SHIELD);
+    AddConstant("ResearchPhazerShooter",        RESEARCH_PHAZER);
+    AddConstant("ResearchLegged",               RESEARCH_iPAW);
+    AddConstant("ResearchOrgaShooter",          RESEARCH_iGUN);
+    AddConstant("ResearchRecycler",             RESEARCH_RECYCLER);
+    AddConstant("ResearchSubber",               RESEARCH_SUBM);
+    AddConstant("ResearchSniffer",              RESEARCH_SNIFFER);
+    AddConstant("ResearchBuilder",              RESEARCH_BUILDER);
+    AddConstant("ResearchTarget",               RESEARCH_TARGET);
+
+    AddConstant("CameraDefault", static_cast<int>(CameraView::DEFAULT));
+    AddConstant("CameraOnboard", static_cast<int>(CameraView::ONBOARD));
+    AddConstant("CameraBack",    static_cast<int>(CameraView::BACK));
+
+    AddConstant("PolskiPortalColobota", 1337);
+
+}
 
 // Updates the class Object.
 

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -69,6 +69,7 @@
 #include "ui/displaytext.h"
 
 #include <cmath>
+#include <string>
 
 using namespace CBot;
 
@@ -3471,11 +3472,11 @@ bool CScriptFunctions::rDeleteFile(CBotVar* var, CBotVar* result, int& exception
     return false;
 }
 
-void CScriptFunctions::InitFunctions(const std::shared_ptr<CBot::CBotContext>& context)
+void CScriptFunctions::InitFunctions(CBot::CBotContext& context)
 {
     auto AddFunction = [&context](const std::string& name, CBot::DefaultRuntimeFunc rExec, CBot::DefaultCompileFunc cComp)
     {
-        if (!context->AddFunction(name, rExec, cComp))
+        if (!context.AddFunction(name, rExec, cComp))
             GetLogger()->Error("Function '%s()' redefined", name.c_str());
     };
 
@@ -3553,11 +3554,11 @@ void CScriptFunctions::InitFunctions(const std::shared_ptr<CBot::CBotContext>& c
     AddFunction("destroy",   rDestroy,   cOneObject);
 }
 
-void CScriptFunctions::InitContextGlobal(const std::shared_ptr<CBot::CBotContext>& globalContext)
+void CScriptFunctions::InitContextGlobal(CBot::CBotContext& globalContext)
 {
     auto AddConstant = [&globalContext](const std::string& name, int num)
     {
-        if (!globalContext->AddConstant<int>(name, num))
+        if (!globalContext.AddConstant<int>(name, num))
             GetLogger()->Error("Constant '%%' redefined", name);
     };
 
@@ -3649,11 +3650,11 @@ void CScriptFunctions::InitContextGlobal(const std::shared_ptr<CBot::CBotContext
     AddConstant("PolskiPortalColobota", 1337);
 
     // Find the class Point.
-    auto pnt = globalContext->FindClass("point");
+    auto pnt = globalContext.FindClass("point");
 
     const auto protectReadOnly = CBotVar::ProtectionLevel::ReadOnly;
 
-    auto bc = globalContext->CreateClass("object", nullptr);
+    auto bc = globalContext.CreateClass("object", nullptr);
     bc->AddItem("category",    { CBotTypInt }, protectReadOnly);
     bc->AddItem("position",    { CBotTypClass, pnt }, protectReadOnly);
     bc->AddItem("orientation", { CBotTypFloat }, protectReadOnly);
@@ -3672,8 +3673,8 @@ void CScriptFunctions::InitContextGlobal(const std::shared_ptr<CBot::CBotContext
     bc->AddItem("velocity",    { CBotTypClass, pnt }, protectReadOnly);
     bc->SetUpdateFunc(CScriptFunctions::uObject);
 
-    globalContext->SetFileAccessHandler(std::make_unique<CBotFileAccessHandlerColobot>());
-    globalContext->AddFunction("deletefile", rDeleteFile, cString);
+    globalContext.SetFileAccessHandler(std::make_unique<CBotFileAccessHandlerColobot>());
+    globalContext.AddFunction("deletefile", rDeleteFile, cString);
 }
 
 // Updates the class Object.

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -309,7 +309,11 @@ CBotTypResult CScriptFunctions::cGetObject(CBotVar* &var, void* user)
     var = var->GetNext();
     if ( var != nullptr )  return CBotTypResult(CBotErrOverParam);
 
-    return CBotTypResult(CBotTypPointer, "object");
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("object");
+
+    return CBotTypResult(CBotTypPointer, pClass);
 }
 
 // Instruction "retobjectbyid(rank)".
@@ -815,12 +819,20 @@ static CBotTypResult compileSearch(CBotVar* &var, void* user, CBotTypResult retu
 
 CBotTypResult CScriptFunctions::cSearch(CBotVar* &var, void* user)
 {
-    return compileSearch(var, user, CBotTypResult(CBotTypPointer, "object"));
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("object");
+
+    return compileSearch(var, user, CBotTypResult(CBotTypPointer, pClass));
 }
 
 CBotTypResult CScriptFunctions::cSearchAll(CBotVar* &var, void* user)
 {
-    return compileSearch(var, user, CBotTypResult(CBotTypArrayPointer, CBotTypResult(CBotTypPointer, "object")));
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("object");
+
+    return compileSearch(var, user, CBotTypResult(CBotTypArrayPointer, CBotTypResult(CBotTypPointer, pClass)));
 }
 
 static bool runSearch(CBotVar* var, glm::vec3 pos, int& exception, std::function<bool(std::vector<ObjectType>, glm::vec3, float, float, bool, RadarFilter)> code)
@@ -994,14 +1006,22 @@ static CBotTypResult compileRadar(CBotVar* &var, void* user, CBotTypResult retur
 
 CBotTypResult CScriptFunctions::cRadarAll(CBotVar* &var, void* user)
 {
-    return compileRadar(var, user, CBotTypResult(CBotTypArrayPointer, CBotTypResult(CBotTypPointer, "object")));
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("object");
+
+    return compileRadar(var, user, CBotTypResult(CBotTypArrayPointer, CBotTypResult(CBotTypPointer, pClass)));
 }
 
 // Compilation of instruction "radar(type, angle, focus, min, max, sens)".
 
 CBotTypResult CScriptFunctions::cRadar(CBotVar* &var, void* user)
 {
-    return compileRadar(var, user, CBotTypResult(CBotTypPointer, "object"));
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("object");
+
+    return compileRadar(var, user, CBotTypResult(CBotTypPointer, pClass));
 }
 
 static bool runRadar(CBotVar* var, std::function<bool(std::vector<ObjectType>, float, float, float, float, bool, RadarFilter)> code)
@@ -1793,24 +1813,37 @@ CBotTypResult CScriptFunctions::cSpace(CBotVar* &var, void* user)
 {
     CBotTypResult   ret;
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    ret = cPoint(var, user);
-    if ( ret.GetType() != 0 )  return ret;
+    if ( var != nullptr )
+    {
+        ret = cPoint(var, user);
+        if ( ret.GetType() != 0 )  return ret;
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
+        if ( var != nullptr )
+        {
+            if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
+            var = var->GetNext();
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
+            if ( var != nullptr )
+            {
+                if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
+                var = var->GetNext();
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
+                if ( var != nullptr )
+                {
+                    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
+                    var = var->GetNext();
 
-    if ( var != nullptr )  return CBotTypResult(CBotErrOverParam);
-    return CBotTypResult(CBotTypIntrinsic, "point");
+                    if ( var != nullptr )  return CBotTypResult(CBotErrOverParam);
+                }
+            }
+        }
+    }
+
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("point");
+
+    return CBotTypResult(CBotTypIntrinsic, pClass);
 }
 
 // Instruction "space(center, rMin, rMax, dist)".
@@ -1894,20 +1927,31 @@ CBotTypResult CScriptFunctions::cFlatSpace(CBotVar* &var, void* user)
     if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
     var = var->GetNext();
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
+    if ( var != nullptr )
+    {
+        if (var->GetType() > CBotTypDouble) return CBotTypResult(CBotErrBadNum);
+        var = var->GetNext();
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
+        if ( var != nullptr )
+        {
+            if (var->GetType() > CBotTypDouble) return CBotTypResult(CBotErrBadNum);
+            var = var->GetNext();
 
-    if ( var == nullptr )  return CBotTypResult(CBotTypIntrinsic, "point");
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
+            if ( var != nullptr )
+            {
+                if (var->GetType() > CBotTypDouble) return CBotTypResult(CBotErrBadNum);
+                var = var->GetNext();
 
-    if ( var != nullptr )  return CBotTypResult(CBotErrOverParam);
-    return CBotTypResult(CBotTypIntrinsic, "point");
+                if ( var != nullptr )  return CBotTypResult(CBotErrOverParam);
+            }
+        }
+    }
+
+    auto script = static_cast<CScript*>(user);
+    auto& context = script->m_main->GetCBotContextGlobal();
+    auto pClass = context->FindClass("point");
+
+    return CBotTypResult(CBotTypIntrinsic, pClass);
 }
 
 bool CScriptFunctions::rFlatSpace(CBotVar* var, CBotVar* result, int& exception, void* user)
@@ -3282,97 +3326,6 @@ bool CScriptFunctions::rCameraFocus(CBotVar* var, CBotVar* result, int& exceptio
     return true;
 }
 
-
-// Compilation of class "point".
-
-CBotTypResult CScriptFunctions::cPointConstructor(CBotVar* pThis, CBotVar* &var)
-{
-    if ( !pThis->IsElemOfClass("point") )  return CBotTypResult(CBotErrBadNum);
-
-    if ( var == nullptr )  return CBotTypResult(0);  // ok if no parameter
-
-    // First parameter (x):
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
-
-    // Second parameter (y):
-    if ( var == nullptr )  return CBotTypResult(CBotErrLowParam);
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
-
-    // Third parameter (z):
-    if ( var == nullptr )  // only 2 parameters?
-    {
-        return CBotTypResult(0);  // this function returns void
-    }
-
-    if ( var->GetType() > CBotTypDouble )  return CBotTypResult(CBotErrBadNum);
-    var = var->GetNext();
-    if ( var != nullptr )  return CBotTypResult(CBotErrOverParam);
-
-    return CBotTypResult(0);  // this function returns void
-}
-
-//Execution of the class "point".
-
-bool CScriptFunctions::rPointConstructor(CBotVar* pThis, CBotVar* var, CBotVar* pResult, int& Exception, void* user)
-{
-    CBotVar     *pX, *pY, *pZ;
-
-    if ( var == nullptr )  return true;  // constructor with no parameters is ok
-
-    if ( var->GetType() > CBotTypDouble )
-    {
-        Exception = CBotErrBadNum;  return false;
-    }
-
-    pX = pThis->GetItem("x");
-    if ( pX == nullptr )
-    {
-        Exception = CBotErrUndefItem;  return false;
-    }
-    pX->SetValFloat( var->GetValFloat() );
-    var = var->GetNext();
-
-    if ( var == nullptr )
-    {
-        Exception = CBotErrLowParam;  return false;
-    }
-
-    if ( var->GetType() > CBotTypDouble )
-    {
-        Exception = CBotErrBadNum;  return false;
-    }
-
-    pY = pThis->GetItem("y");
-    if ( pY == nullptr )
-    {
-        Exception = CBotErrUndefItem;  return false;
-    }
-    pY->SetValFloat( var->GetValFloat() );
-    var = var->GetNext();
-
-    if ( var == nullptr )
-    {
-        return true;  // ok with only two parameters
-    }
-
-    pZ = pThis->GetItem("z");
-    if ( pZ == nullptr )
-    {
-        Exception = CBotErrUndefItem;  return false;
-    }
-    pZ->SetValFloat( var->GetValFloat() );
-    var = var->GetNext();
-
-    if ( var != nullptr )
-    {
-        Exception = CBotErrOverParam;  return false;
-    }
-
-    return  true;  // no interruption
-}
-
 class CBotFileColobot : public CBotFile
 {
 public:
@@ -3516,48 +3469,6 @@ bool CScriptFunctions::rDeleteFile(CBotVar* var, CBotVar* result, int& exception
     if (script->m_errMode != ERM_STOP) return true;
     exception = CBotErrRead;
     return false;
-}
-
-// Initializes all functions for module CBOT.
-
-void CScriptFunctions::Init()
-{
-    CBotProgram::Init();
-
-    CBotClass* bc;
-
-    const auto& context = CRobotMain::GetInstancePointer()->GetCBotContextGlobal();
-    bc = CBotClass::Find("file");
-    bc->SetContext(context);
-
-    // Add the class Point.
-    bc = CBotClass::Create("point", nullptr, true);  // intrinsic class
-    bc->AddItem("x", CBotTypFloat);
-    bc->AddItem("y", CBotTypFloat);
-    bc->AddItem("z", CBotTypFloat);
-    bc->AddFunction("point", rPointConstructor, cPointConstructor);
-    bc->SetContext(context);
-
-    // Adds the class Object.
-    bc = CBotClass::Create("object", nullptr);
-    bc->SetContext(context);
-
-    bc->AddItem("category",    CBotTypResult(CBotTypInt), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("position",    CBotTypResult(CBotTypClass, "point"), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("orientation", CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("pitch",       CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("roll",        CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("energyLevel", CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("shieldLevel", CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("temperature", CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("altitude",    CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("lifeTime",    CBotTypResult(CBotTypFloat), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("energyCell",  CBotTypResult(CBotTypPointer, "object"), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("load",        CBotTypResult(CBotTypPointer, "object"), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("id",          CBotTypResult(CBotTypInt), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("team",        CBotTypResult(CBotTypInt), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("dead",        CBotTypResult(CBotTypBoolean), CBotVar::ProtectionLevel::ReadOnly);
-    bc->AddItem("velocity",    CBotTypResult(CBotTypClass, "point"), CBotVar::ProtectionLevel::ReadOnly);
 }
 
 void CScriptFunctions::InitFunctions(const std::shared_ptr<CBot::CBotContext>& context)
@@ -3737,6 +3648,30 @@ void CScriptFunctions::InitContextGlobal(const std::shared_ptr<CBot::CBotContext
 
     AddConstant("PolskiPortalColobota", 1337);
 
+    // Find the class Point.
+    auto pnt = globalContext->FindClass("point");
+
+    const auto protectReadOnly = CBotVar::ProtectionLevel::ReadOnly;
+
+    auto bc = globalContext->CreateClass("object", nullptr);
+    bc->AddItem("category",    { CBotTypInt }, protectReadOnly);
+    bc->AddItem("position",    { CBotTypClass, pnt }, protectReadOnly);
+    bc->AddItem("orientation", { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("pitch",       { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("roll",        { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("energyLevel", { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("shieldLevel", { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("temperature", { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("altitude",    { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("lifeTime",    { CBotTypFloat }, protectReadOnly);
+    bc->AddItem("energyCell",  { CBotTypPointer, bc }, protectReadOnly);
+    bc->AddItem("load",        { CBotTypPointer, bc }, protectReadOnly);
+    bc->AddItem("id",          { CBotTypInt }, protectReadOnly);
+    bc->AddItem("team",        { CBotTypInt }, protectReadOnly);
+    bc->AddItem("dead",        { CBotTypBoolean }, protectReadOnly);
+    bc->AddItem("velocity",    { CBotTypClass, pnt }, protectReadOnly);
+    bc->SetUpdateFunc(CScriptFunctions::uObject);
+
     globalContext->SetFileAccessHandler(std::make_unique<CBotFileAccessHandlerColobot>());
     globalContext->AddFunction("deletefile", rDeleteFile, cString);
 }
@@ -3907,13 +3842,11 @@ void CScriptFunctions::uObject(CBotVar* botThis, void* user)
 
 CBotVar* CScriptFunctions::CreateObjectVar(CObject* obj)
 {
-    CBotClass* bc = CBotClass::Find("object");
-    if ( bc != nullptr )
-    {
-        bc->SetUpdateFunc(CScriptFunctions::uObject);
-    }
+    const auto& context = CRobotMain::GetInstancePointer()->GetCBotContextGlobal();
+    auto pClass = context->FindClass("object");
+    pClass->SetUpdateFunc(CScriptFunctions::uObject);
 
-    CBotVar* botVar = CBotVar::Create("", CBotTypResult(CBotTypClass, "object"));
+    CBotVar* botVar = CBotVar::Create("", CBotTypResult(CBotTypClass, pClass));
     botVar->SetUserPointer(CBotUserPointer::Create(obj));
     return botVar;
 }

--- a/colobot-base/src/script/scriptfunc.h
+++ b/colobot-base/src/script/scriptfunc.h
@@ -45,6 +45,7 @@ class CScriptFunctions
 {
 public:
     static void Init();
+    static void InitFunctions(const std::shared_ptr<CBot::CBotContext>& context);
     static void InitContextGlobal(const std::shared_ptr<CBot::CBotContext>& globalContext);
 
     static CBot::CBotVar* CreateObjectVar(CObject* obj);
@@ -155,6 +156,8 @@ private:
     static bool rFactory(CBot::CBotVar* var, CBot::CBotVar* result, int& exception, void* user);
     static bool rResearch(CBot::CBotVar* var, CBot::CBotVar* result, int& exception, void* user);
     static bool rDestroy(CBot::CBotVar* var, CBot::CBotVar* result, int& exception, void* user);
+
+    static bool rDeleteFile(CBot::CBotVar* var, CBot::CBotVar* result, int& exception, void* user);
 
     static CBot::CBotTypResult cClassNull(CBot::CBotVar* thisclass, CBot::CBotVar* &var);
     static CBot::CBotTypResult cClassOneFloat(CBot::CBotVar* thisclass, CBot::CBotVar* &var);

--- a/colobot-base/src/script/scriptfunc.h
+++ b/colobot-base/src/script/scriptfunc.h
@@ -44,7 +44,6 @@ class CBotVar;
 class CScriptFunctions
 {
 public:
-    static void Init();
     static void InitFunctions(const std::shared_ptr<CBot::CBotContext>& context);
     static void InitContextGlobal(const std::shared_ptr<CBot::CBotContext>& globalContext);
 
@@ -161,9 +160,6 @@ private:
 
     static CBot::CBotTypResult cClassNull(CBot::CBotVar* thisclass, CBot::CBotVar* &var);
     static CBot::CBotTypResult cClassOneFloat(CBot::CBotVar* thisclass, CBot::CBotVar* &var);
-
-    static CBot::CBotTypResult cPointConstructor(CBot::CBotVar* pThis, CBot::CBotVar* &var);
-    static bool rPointConstructor(CBot::CBotVar* pThis, CBot::CBotVar* var, CBot::CBotVar* pResult, int& Exception, void* user);
 
     static void uObject(CBot::CBotVar* botThis, void* user);
 

--- a/colobot-base/src/script/scriptfunc.h
+++ b/colobot-base/src/script/scriptfunc.h
@@ -35,6 +35,7 @@ class CScript;
 class CExchangePost;
 namespace CBot
 {
+class CBotContext;
 class CBotTypResult;
 class CBotVar;
 }
@@ -44,6 +45,7 @@ class CScriptFunctions
 {
 public:
     static void Init();
+    static void InitContextGlobal(const std::shared_ptr<CBot::CBotContext>& globalContext);
 
     static CBot::CBotVar* CreateObjectVar(CObject* obj);
     static void DestroyObjectVar(CBot::CBotVar* botVar, bool permanent);

--- a/colobot-base/src/script/scriptfunc.h
+++ b/colobot-base/src/script/scriptfunc.h
@@ -26,10 +26,6 @@
 
 #include "common/error.h"
 
-#include <string>
-#include <unordered_map>
-#include <memory>
-
 class CObject;
 class CScript;
 class CExchangePost;
@@ -44,8 +40,8 @@ class CBotVar;
 class CScriptFunctions
 {
 public:
-    static void InitFunctions(const std::shared_ptr<CBot::CBotContext>& context);
-    static void InitContextGlobal(const std::shared_ptr<CBot::CBotContext>& globalContext);
+    static void InitFunctions(CBot::CBotContext& context);
+    static void InitContextGlobal(CBot::CBotContext& globalContext);
 
     static CBot::CBotVar* CreateObjectVar(CObject* obj);
     static void DestroyObjectVar(CBot::CBotVar* botVar, bool permanent);

--- a/test/src/CBot/CBotToken_test.cpp
+++ b/test/src/CBot/CBotToken_test.cpp
@@ -20,6 +20,8 @@
 #include "CBot/CBotToken.h"
 #include "CBot/CBotProgram.h"
 
+#include "CBot/context/cbot_context.h"
+
 #include <gtest/gtest.h>
 
 using namespace CBot;
@@ -46,7 +48,8 @@ protected:
 
     void ExecuteTest(const std::string& code, std::vector<TokenTest> data)
     {
-        auto tokens = CBotToken::CompileTokens(code);
+        auto context = CBotContext::CreateGlobalContext();
+        auto tokens = CBotToken::CompileTokens(code, *context);
         ASSERT_TRUE(tokens != nullptr);
         CBotToken* token = tokens.get()->GetNext(); // TODO: why do we always have to skip the first one :/
         ASSERT_TRUE(token != nullptr);

--- a/test/src/CBot/CBotToken_test.cpp
+++ b/test/src/CBot/CBotToken_test.cpp
@@ -31,12 +31,10 @@ class CBotTokenUT : public testing::Test
 public:
     CBotTokenUT()
     {
-        CBotProgram::Init();
     }
 
     ~CBotTokenUT()
     {
-        CBotProgram::Free();
     }
 
 protected:

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -224,6 +224,7 @@ private:
 
 protected:
     std::shared_ptr<CBotContext> m_context;
+    const std::shared_ptr<CBotContext>& GetCBotContext() { return m_context; }
 
     std::unique_ptr<CBotProgram> ExecuteTest(const std::string& code, CBotError expectedError = CBotNoErr)
     {
@@ -428,6 +429,44 @@ TEST_F(CBotUT, ClassCompileErrors)
         "public class TestClass extends 1234",
         CBotErrNoClassName
     );
+}
+
+TEST_F(CBotUT, DefinedConstants)
+{
+    ExecuteTest(R"(
+        extern void Error_Constants_Defined()
+        {
+            ASSERT( CBotErrZeroDiv    != 0 );
+            ASSERT( CBotErrNotInit    != 0 );
+            ASSERT( CBotErrBadThrow   != 0 );
+            ASSERT( CBotErrNoRetVal   != 0 );
+            ASSERT( CBotErrNoRun      != 0 );
+            ASSERT( CBotErrUndefFunc  != 0 );
+            ASSERT( CBotErrNotClass   != 0 );
+            ASSERT( CBotErrNull       != 0 );
+            ASSERT( CBotErrNan        != 0 );
+            ASSERT( CBotErrOutArray   != 0 );
+            ASSERT( CBotErrStackOver  != 0 );
+            ASSERT( CBotErrDeletedPtr != 0 );
+        }
+    )");
+
+    const auto& context = CBotUT::GetCBotContext();
+
+    context->AddConstant<std::string>("String_Constant", "a string");
+    context->AddConstant<float>("Float_Constant", 2.71828f);
+    context->AddConstant<int>("Int_Constant", 3210);
+    // TODO: Currently only int, float, and string.
+    // Other primitive types will work, but the specializations are not yet defined in list_constant.cpp
+
+    ExecuteTest(R"(
+        extern void Other_Constants_Defined()
+        {
+            ASSERT( String_Constant == "a string" );
+            ASSERT( Float_Constant == 2.71828 );
+            ASSERT( Int_Constant == 3210 );
+        }
+    )");
 }
 
 TEST_F(CBotUT, DivideByZero)

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -35,8 +35,9 @@ public:
     {
         m_context = CBot::CBotContext::CreateGlobalContext();
         CBotProgram::Init();
-        CBotProgram::AddFunction("FAIL", rFail, cFail);
-        CBotProgram::AddFunction("ASSERT", rAssert, cAssert);
+
+        m_context->AddFunction("FAIL", rFail, cFail);
+        m_context->AddFunction("ASSERT", rAssert, cAssert);
     }
 
     ~CBotUT()

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -34,7 +34,6 @@ public:
     CBotUT()
     {
         m_context = CBot::CBotContext::CreateGlobalContext();
-        CBotProgram::Init();
 
         m_context->AddFunction("FAIL", rFail, cFail);
         m_context->AddFunction("ASSERT", rAssert, cAssert);
@@ -42,7 +41,6 @@ public:
 
     ~CBotUT()
     {
-        CBotProgram::Free();
     }
 
 private:
@@ -213,15 +211,15 @@ private:
         if (!program->SaveState(sstr))
             throw CBotTestFail("CBotProgram::SaveState Failed");
 
-        if (!CBotClass::SaveStaticState(sstr, *context))
-            throw CBotTestFail("CBotClass::SaveStaticState Failed");
+        if (!context->WriteStaticState(sstr))
+            throw CBotTestFail("CBotContext::WriteStaticState Failed");
         // restore
         context->ClearInstanceList();
         if (!program->RestoreState(sstr))
             throw CBotTestFail("CBotProgram::RestoreState Failed");
 
-        if (!CBotClass::RestoreStaticState(sstr, *context))
-            throw CBotTestFail("CBotClass::RestoreStaticState Failed");
+        if (!CBotContext::ReadStaticState(sstr, *context))
+            throw CBotTestFail("CBotContext::ReadStaticState Failed");
     }
 
 protected:

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -231,8 +231,7 @@ protected:
         CBotError expectedCompileError = expectedError < 6000 ? expectedError : CBotNoErr;
         CBotError expectedRuntimeError = expectedError >= 6000 ? expectedError : CBotNoErr;
 
-        auto program = std::make_unique<CBotProgram>(nullptr);
-        program->SetContext(m_context);
+        auto program = std::make_unique<CBotProgram>(m_context);
 
         std::vector<std::string> tests;
         program->Compile(code, tests);

--- a/test/src/CBot/CBot_test.cpp
+++ b/test/src/CBot/CBot_test.cpp
@@ -218,7 +218,7 @@ private:
         if (!program->RestoreState(sstr))
             throw CBotTestFail("CBotProgram::RestoreState Failed");
 
-        if (!CBotContext::ReadStaticState(sstr, *context))
+        if (!context->ReadStaticState(sstr))
             throw CBotTestFail("CBotContext::ReadStaticState Failed");
     }
 

--- a/tools/cbot-console/src/console.cpp
+++ b/tools/cbot-console/src/console.cpp
@@ -63,8 +63,8 @@ int main(int argc, char* argv[])
     }
 
     // Initialize the CBot engine, add standard library functions
-    CBotProgram::Init();
-    CBotProgram::AddFunction("message", rMessage, cMessage);
+    auto context = CBotContext::CreateGlobalContext();
+    context->AddFunction("message", rMessage, cMessage);
 
     // Error message strings are stored on Colobot side (meh!) so let's initialize that
     InitializeRestext();
@@ -73,6 +73,7 @@ int main(int argc, char* argv[])
     // Compile the program
     std::vector<std::string> externFunctions;
     std::unique_ptr<CBotProgram> program{new CBotProgram(nullptr)};
+    program->SetContext(context);
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;

--- a/tools/cbot-console/src/console.cpp
+++ b/tools/cbot-console/src/console.cpp
@@ -72,8 +72,7 @@ int main(int argc, char* argv[])
 
     // Compile the program
     std::vector<std::string> externFunctions;
-    std::unique_ptr<CBotProgram> program{new CBotProgram(nullptr)};
-    program->SetContext(context);
+    auto program = std::make_unique<CBotProgram>(context);
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;

--- a/tools/cbot-graph/src/compile_graph.cpp
+++ b/tools/cbot-graph/src/compile_graph.cpp
@@ -52,9 +52,6 @@ int main(int argc, char* argv[])
         code += "\n";
     }
 
-    // Initialize the CBot engine
-    CBotProgram::Init();
-
     // Compile the program
     std::vector<std::string> externFunctions;
     std::unique_ptr<CBotProgram> program{new CBotProgram(nullptr)};
@@ -80,9 +77,6 @@ int main(int argc, char* argv[])
         CBotDebug::DumpCompiledProgram(program.get());
         program->Stop();
     }
-
-    // Free the engine
-    CBotProgram::Free();
 
     return 0;
 }

--- a/tools/cbot-graph/src/compile_graph.cpp
+++ b/tools/cbot-graph/src/compile_graph.cpp
@@ -52,9 +52,11 @@ int main(int argc, char* argv[])
         code += "\n";
     }
 
+    auto context = CBotContext::CreateGlobalContext();
+
     // Compile the program
     std::vector<std::string> externFunctions;
-    std::unique_ptr<CBotProgram> program{new CBotProgram(nullptr)};
+    auto program = std::make_unique<CBotProgram>(context);
     if (!program->Compile(code.c_str(), externFunctions, nullptr))
     {
         CBotError error;


### PR DESCRIPTION
@hexagonrecursion , here it is. I had to move it all manually.

**Refactor SaveState to handle circular references**
* Removes static data member CBotVarClass::m_instances.
* Removes #defines OBJECTDELETED and OBJECTCREATED

**Refactor DefineNum to AddConstant**
* Defined constants can now be a string or any primitive data type.
 
**Make external call list separate for teams**
**Make list of public classes separate for teams**
**Make list of public functions separate for teams**

This obviously breaks compatibility with any previous ```cbot.run``` file.
Any known issues with saved games would need to be re-tested with new saved games.

So far, each commit passes all unit tests and exposes zero memory leaks.

Any and all feedback is welcome.

I have some other features and fixes to push to other branches based on these changes.

