### PR TITLE
Fix incorrect save/load of objects

### DIFF
--- a/CBot/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.cpp
@@ -440,20 +440,22 @@ bool CBotVarClass::Save1State(std::ostream &ostr, CBotContext& context)
     auto pClass = m_type.GetClass();
     if (pClass != nullptr && pClass->IsIntrinsic())
     {
-        if (!WriteLong(ostr, 0)) return false;
+        if (!WriteInt(ostr, /*isExisting*/ 0)) return false;
+        if (!WriteInt(ostr, /*id*/ 0)) return false;
     }
     else
     {
-        auto pos = context.FindInstance(this);
-        if (pos == -1)
+        int id = context.FindInstance(this);
+        if (id == -1)
         {
-            // 0 to mark the instance as saved at this position
-            if (!WriteLong(ostr, 0)) return false;
-            context.DeclareInstance(ostr.tellp(), this);
+            if (!WriteInt(ostr, /*isExisting*/ 0)) return false;
+            id = context.DeclareInstance(this);
+            if (!WriteInt(ostr, id)) return false;
         }
-        else // save only the stream position of the already saved instance
+        else // save only the id of the already saved instance
         {
-            return WriteLong(ostr, pos);
+            if (!WriteInt(ostr, /*isExisting*/ 1)) return false;
+            return WriteInt(ostr, id);
         }
     }
 

--- a/CBot/src/CBot/context/cbot_context.cpp
+++ b/CBot/src/CBot/context/cbot_context.cpp
@@ -69,11 +69,20 @@ CBotContext::~CBotContext()
 void CBotContext::ClearInstanceList()
 {
     m_globalData->m_instances.clear();
+    m_globalData->m_next = 1;
 }
 
-void CBotContext::DeclareInstance(long pos, CBotVar* var)
+int CBotContext::DeclareInstance(CBotVar* var)
 {
-    m_globalData->m_instances[pos] = var;
+    int id = m_globalData->m_next++;
+    m_globalData->m_instances[id] = var;
+    return id;
+}
+
+void CBotContext::DeclareInstance(int id, CBotVar* var)
+{
+    assert(m_globalData->m_next == 1);
+    m_globalData->m_instances[id] = var;
 }
 
 CBotClass* CBotContext::FindClass(const std::string& name) const
@@ -138,14 +147,14 @@ bool CBotContext::ReadStaticState(std::istream& istr, CBotContext& context)
     return true;
 }
 
-CBotVar* CBotContext::FindInstance(long pos) const
+CBotVar* CBotContext::FindInstance(int pos) const
 {
     auto it = m_globalData->m_instances.find(pos);
     if (it != m_globalData->m_instances.end()) return it->second;
     return nullptr;
 }
 
-long CBotContext::FindInstance(CBotVar* var) const
+int CBotContext::FindInstance(CBotVar* var) const
 {
     for (const auto& item : m_globalData->m_instances)
         if (item.second == var) return item.first;

--- a/CBot/src/CBot/context/cbot_context.h
+++ b/CBot/src/CBot/context/cbot_context.h
@@ -80,10 +80,11 @@ public:
 
     static bool ReadStaticState(std::istream& istr, CBotContext& context);
 
-    long FindInstance(CBotVar* var) const;
-    CBotVar* FindInstance(long pos) const;
+    int FindInstance(CBotVar* var) const;
+    CBotVar* FindInstance(int id) const;
     void ClearInstanceList();
-    void DeclareInstance(long pos, CBotVar* var);
+    int DeclareInstance(CBotVar* var);
+    void DeclareInstance(int id, CBotVar* var);
 
     bool IsDefinedConstant(const std::string& name) const override;
 
@@ -108,7 +109,8 @@ private:
     {
         long m_nextUniqueID = 10000;
         CBotFileAccessHandlerUPtr m_fileHandler;
-        std::unordered_map<long, CBotVar*> m_instances;
+        std::unordered_map<int, CBotVar*> m_instances;
+        int m_next = 1;
     };
     std::shared_ptr<CBotContext::GlobalData> m_globalData;
 


### PR DESCRIPTION
1. We were using `tellp()` to assign a unique number to each object we save. This requires the output stream to be seekable because for non-seekable streams `tellp()` always returns -1. When saving cbot.run we use COutputStream, which is not seekable. Ref: https://github.com/melex750/colobot/pull/2#issuecomment-2571678721
2. We assumed that `tellp()` returns a unique number and that `tellg()` returns the same number when we read the file later. This requires `CBotVarClass::Save1State()` and `CBotVar::RestoreVar()` to operate directly on the stream that represents the full cbot.run, but we write each stack to it's own isolated stream. Ref: https://github.com/melex750/colobot/pull/2#issuecomment-2571667374

Solution:
1. Don't use `tellp()` and `tellg()`
2. When saving use an incrementing id for each new object
3. Add a new field to the file format (`isExisting`) - 0 if this is the first time we see this object while generating the current save file, 1 if this is a reference to a previously saved object