### PR TITLE
Refactor user pointers

### DIFF
--- a/CBot/CMakeLists.txt
+++ b/CBot/CMakeLists.txt
@@ -167,7 +167,6 @@ target_sources(CBot PRIVATE
     src/CBot/CBotVar/CBotVarString.h
     src/CBot/context/cbot_context.cpp
     src/CBot/context/cbot_context.h
-    src/CBot/context/cbot_user_pointer.h
     src/CBot/context/context_observer.h
     src/CBot/context/context_owner.h
     src/CBot/context/external_call_list_interface.h
@@ -181,6 +180,8 @@ target_sources(CBot PRIVATE
     src/CBot/stdlib/StringFunctions.cpp
     src/CBot/stdlib/stdlib.h
     src/CBot/stdlib/stdlib_public.h
+    src/CBot/user_pointer.cpp
+    src/CBot/user_pointer.h
 )
 
 target_include_directories(CBot PUBLIC src)

--- a/CBot/src/CBot/CBotInstr/CBotFieldExpr.cpp
+++ b/CBot/src/CBot/CBotInstr/CBotFieldExpr.cpp
@@ -25,8 +25,6 @@
 
 #include "CBot/CBotVar/CBotVarClass.h"
 
-#include "CBot/context/cbot_user_pointer.h"
-
 #include <cassert>
 #include <sstream>
 
@@ -88,13 +86,10 @@ bool CBotFieldExpr::ExecuteVar(CBotVar* &pVar, CBotStack* &pile, CBotToken* prev
             return pj->Return(pile);
         }
 
-        if (const auto& userPtr = pItem->GetUserPointer())
+        if (pItem->GetUserPointer().GetState() == PtrState::Dead)
         {
-            if (userPtr->GetPointerAs<void>() == nullptr)
-            {
-                pile->SetError(CBotErrDeletedPtr, prevToken);
-                return pj->Return(pile);
-            }
+            pile->SetError(CBotErrDeletedPtr, prevToken);
+            return pj->Return(pile);
         }
     }
 

--- a/CBot/src/CBot/CBotStack.cpp
+++ b/CBot/src/CBot/CBotStack.cpp
@@ -31,7 +31,6 @@
 #include "CBot/CBotProgram.h"
 
 #include "CBot/context/cbot_context.h"
-#include "CBot/context/cbot_user_pointer.h"
 
 #include <cassert>
 #include <cstdint>

--- a/CBot/src/CBot/CBotVar/CBotVar.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVar.cpp
@@ -41,8 +41,6 @@
 
 #include "CBot/CBotEnums.h"
 
-#include "CBot/context/cbot_user_pointer.h"
-
 #include <cassert>
 #include <cmath>
 #include <cstdio>
@@ -98,14 +96,17 @@ void CBotVar::Update()
 {
 }
 
-void CBotVar::SetUserPointer(std::unique_ptr<CBotUserPointer> user)
+void CBotVar::SetUserPointer(void* user)
 {
 }
 
-const std::unique_ptr<CBotUserPointer>& CBotVar::GetUserPointer()
+void CBotVar::KillUserPointer()
 {
-    const static std::unique_ptr<CBotUserPointer> emptyPtr{nullptr};
-    return emptyPtr;
+}
+
+VarUserPointer CBotVar::GetUserPointer()
+{
+    return {};
 }
 
 void CBotVar::SetUniqNum(long n)

--- a/CBot/src/CBot/CBotVar/CBotVar.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVar.cpp
@@ -104,7 +104,7 @@ void CBotVar::KillUserPointer()
 {
 }
 
-VarUserPointer CBotVar::GetUserPointer()
+CBotVarUserPointer CBotVar::GetUserPointer()
 {
     return {};
 }

--- a/CBot/src/CBot/CBotVar/CBotVar.h
+++ b/CBot/src/CBot/CBotVar/CBotVar.h
@@ -23,6 +23,7 @@
 #include "CBot/CBotTypResult.h"
 #include "CBot/CBotEnums.h"
 #include "CBot/CBotUtils.h"
+#include "CBot/user_pointer.h"
 
 #include <cstdint>
 #include <memory>
@@ -35,7 +36,6 @@ class CBotClass;
 class CBotContext;
 class CBotInstr;
 class CBotToken;
-class CBotUserPointer;
 class CBotVar;
 class CBotVarClass;
 
@@ -149,13 +149,17 @@ public:
      * \brief Set a custom pointer associated with this variable
      * \param user custom pointer to set
      */
-    virtual void SetUserPointer(std::unique_ptr<CBotUserPointer> user);
+    virtual void SetUserPointer(void* user);
 
     /**
-     * \brief Returns the custom pointer associated with this variable
-     * \return A pointer set with SetUserPointer()
+     * \brief Set user pointer as dead
      */
-    virtual const std::unique_ptr<CBotUserPointer>& GetUserPointer();
+    virtual void KillUserPointer();
+
+    /**
+     * \brief Return the custom pointer associated with this variable
+     */
+    virtual VarUserPointer GetUserPointer();
 
     //@}
 

--- a/CBot/src/CBot/CBotVar/CBotVar.h
+++ b/CBot/src/CBot/CBotVar/CBotVar.h
@@ -159,7 +159,7 @@ public:
     /**
      * \brief Return the custom pointer associated with this variable
      */
-    virtual VarUserPointer GetUserPointer();
+    virtual CBotVarUserPointer GetUserPointer();
 
     //@}
 

--- a/CBot/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.cpp
@@ -26,7 +26,6 @@
 #include "CBot/CBotInstr/CBotInstr.h"
 
 #include "CBot/context/cbot_context.h"
-#include "CBot/context/cbot_user_pointer.h"
 
 #include <cassert>
 
@@ -195,24 +194,23 @@ CBotClass* CBotVarClass::GetClass()
 
 void CBotVarClass::Update()
 {
-    if (!m_userPtr) return;
-
-    void* user = m_userPtr->GetPointerAs<void>();
-
-    if (user == nullptr) return;
-
+    if (m_userPtr.GetState() != PtrState::Alive) return;
+    void* user = m_userPtr.GetPointerAs<void>();
     m_pClass->Update(this, user);
 }
 
-void CBotVarClass::SetUserPointer(std::unique_ptr<CBotUserPointer> user)
+void CBotVarClass::SetUserPointer(void* user)
 {
-    if (m_userPtr)
-        assert(false);
-    else
-        m_userPtr = std::move(user);
+    assert(m_userPtr.GetState() == PtrState::UnInit);
+    m_userPtr.Set(user);
 }
 
-const std::unique_ptr<CBotUserPointer>& CBotVarClass::GetUserPointer()
+void CBotVarClass::KillUserPointer()
+{
+    m_userPtr.Kill();
+}
+
+VarUserPointer CBotVarClass::GetUserPointer()
 {
     return m_userPtr;
 }

--- a/CBot/src/CBot/CBotVar/CBotVarClass.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.cpp
@@ -210,7 +210,7 @@ void CBotVarClass::KillUserPointer()
     m_userPtr.Kill();
 }
 
-VarUserPointer CBotVarClass::GetUserPointer()
+CBotVarUserPointer CBotVarClass::GetUserPointer()
 {
     return m_userPtr;
 }

--- a/CBot/src/CBot/CBotVar/CBotVarClass.h
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.h
@@ -55,8 +55,9 @@ public:
     bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
     void Update() override;
-    void SetUserPointer(std::unique_ptr<CBotUserPointer> user) override;
-    const std::unique_ptr<CBotUserPointer>& GetUserPointer() override;
+    void SetUserPointer(void* user) override;
+    void KillUserPointer() override;
+    VarUserPointer GetUserPointer() override;
 
     CBotVarSPtr GetPointer() override;
 
@@ -78,7 +79,7 @@ private:
     //! Set after constructor is called, allows destructor to be called
     bool m_bConstructor;
 
-    std::unique_ptr<CBotUserPointer> m_userPtr;
+    VarUserPointer m_userPtr;
 
     friend class CBotVar;
     friend class CBotVarPointer;

--- a/CBot/src/CBot/CBotVar/CBotVarClass.h
+++ b/CBot/src/CBot/CBotVar/CBotVarClass.h
@@ -57,7 +57,7 @@ public:
     void Update() override;
     void SetUserPointer(void* user) override;
     void KillUserPointer() override;
-    VarUserPointer GetUserPointer() override;
+    CBotVarUserPointer GetUserPointer() override;
 
     CBotVarSPtr GetPointer() override;
 
@@ -79,7 +79,7 @@ private:
     //! Set after constructor is called, allows destructor to be called
     bool m_bConstructor;
 
-    VarUserPointer m_userPtr;
+    CBotVarUserPointer m_userPtr;
 
     friend class CBotVar;
     friend class CBotVarPointer;

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
@@ -71,7 +71,7 @@ void CBotVarPointer::KillUserPointer()
     if (m_pVarClass) m_pVarClass->KillUserPointer();
 }
 
-VarUserPointer CBotVarPointer::GetUserPointer()
+CBotVarUserPointer CBotVarPointer::GetUserPointer()
 {
     if (m_pVarClass) return m_pVarClass->GetUserPointer();
     return {};

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.h
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.h
@@ -58,8 +58,9 @@ public:
     bool Save1State(std::ostream &ostr, CBotContext& context) override;
 
     void Update() override;
-    void SetUserPointer(std::unique_ptr<CBotUserPointer> user) override;
-    const std::unique_ptr<CBotUserPointer>& GetUserPointer() override;
+    void SetUserPointer(void* user) override;
+    void KillUserPointer() override;
+    VarUserPointer GetUserPointer() override;
 
     bool Eq(CBotVar* left, CBotVar* right) override;
     bool Ne(CBotVar* left, CBotVar* right) override;

--- a/CBot/src/CBot/CBotVar/CBotVarPointer.h
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.h
@@ -60,7 +60,7 @@ public:
     void Update() override;
     void SetUserPointer(void* user) override;
     void KillUserPointer() override;
-    VarUserPointer GetUserPointer() override;
+    CBotVarUserPointer GetUserPointer() override;
 
     bool Eq(CBotVar* left, CBotVar* right) override;
     bool Ne(CBotVar* left, CBotVar* right) override;

--- a/CBot/src/CBot/stdlib/stdlib_public.h
+++ b/CBot/src/CBot/stdlib/stdlib_public.h
@@ -21,8 +21,6 @@
 
 #include "CBot/stdlib/Compilation.h"
 
-#include "CBot/context/cbot_user_pointer.h"
-
 #include <filesystem>
 #include <memory>
 #include <unordered_map>

--- a/CBot/src/CBot/user_pointer.cpp
+++ b/CBot/src/CBot/user_pointer.cpp
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Colobot: Gold Edition source code
+ * Copyright (C) 2025, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * http://epsitec.ch; http://colobot.info; http://github.com/colobot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://gnu.org/licenses
+ */
+
+#include <cassert>
+#include "CBot/user_pointer.h"
+
+namespace CBot
+{
+
+PtrState VarUserPointer::GetState() const
+{
+    return m_state;
+}
+
+void VarUserPointer::Set(void* p)
+{
+    assert(p != nullptr);
+    m_p = p;
+    m_state = PtrState::Alive;
+}
+
+void VarUserPointer::Kill()
+{
+    m_p = nullptr;
+    m_state = PtrState::Dead;
+}
+
+} // namespace CBot

--- a/CBot/src/CBot/user_pointer.cpp
+++ b/CBot/src/CBot/user_pointer.cpp
@@ -23,19 +23,19 @@
 namespace CBot
 {
 
-PtrState VarUserPointer::GetState() const
+PtrState CBotVarUserPointer::GetState() const
 {
     return m_state;
 }
 
-void VarUserPointer::Set(void* p)
+void CBotVarUserPointer::Set(void* p)
 {
     assert(p != nullptr);
     m_p = p;
     m_state = PtrState::Alive;
 }
 
-void VarUserPointer::Kill()
+void CBotVarUserPointer::Kill()
 {
     m_p = nullptr;
     m_state = PtrState::Dead;

--- a/CBot/src/CBot/user_pointer.h
+++ b/CBot/src/CBot/user_pointer.h
@@ -29,7 +29,7 @@ enum class PtrState
     Dead
 };
 
-class VarUserPointer
+class CBotVarUserPointer
 {
 public:
     PtrState GetState() const;
@@ -38,9 +38,9 @@ public:
     void Set(void* p);
     void Kill();
 
-    VarUserPointer() = default;
-    VarUserPointer(const VarUserPointer&) = default;
-    VarUserPointer& operator=(const VarUserPointer&) = default;
+    CBotVarUserPointer() = default;
+    CBotVarUserPointer(const CBotVarUserPointer&) = default;
+    CBotVarUserPointer& operator=(const CBotVarUserPointer&) = default;
 private:
     PtrState m_state = PtrState::UnInit;
     void* m_p = nullptr;

--- a/CBot/src/CBot/user_pointer.h
+++ b/CBot/src/CBot/user_pointer.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Colobot: Gold Edition source code
- * Copyright (C) 2001-2023, Daniel Roux, EPSITEC SA & TerranovaTeam
+ * Copyright (C) 2025, Daniel Roux, EPSITEC SA & TerranovaTeam
  * http://epsitec.ch; http://colobot.info; http://github.com/colobot
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,36 +19,31 @@
 
 #pragma once
 
-
-#include <memory>
-
 namespace CBot
 {
 
-class CBotUserPointer
+enum class PtrState
+{
+    UnInit,
+    Alive,
+    Dead
+};
+
+class VarUserPointer
 {
 public:
-
-    CBotUserPointer() : m_userPtr(nullptr) {}
-    CBotUserPointer(void* user) :  m_userPtr(user) {}
-
-    static std::unique_ptr<CBotUserPointer> Create()
-    {
-        return std::make_unique<CBotUserPointer>();
-    }
-
-    static std::unique_ptr<CBotUserPointer> Create(void* user)
-    {
-        return std::make_unique<CBotUserPointer>(user);
-    }
-
-    void SetPointerAs(void* user) { m_userPtr = user; }
-
+    PtrState GetState() const;
     template<typename T>
-    T* GetPointerAs() { return static_cast<T*>(m_userPtr); }
+    T* GetPointerAs() { return static_cast<T*>(m_p); }
+    void Set(void* p);
+    void Kill();
 
+    VarUserPointer() = default;
+    VarUserPointer(const VarUserPointer&) = default;
+    VarUserPointer& operator=(const VarUserPointer&) = default;
 private:
-    void* m_userPtr;
+    PtrState m_state = PtrState::UnInit;
+    void* m_p = nullptr;
 };
 
 } // namespace CBot

--- a/colobot-base/src/level/robotmain.cpp
+++ b/colobot-base/src/level/robotmain.cpp
@@ -4895,7 +4895,7 @@ CObject* CRobotMain::IOReadScene(const std::filesystem::path& filename,
 
                     if (objVar)
                     {
-                        objVar->SetUserPointer(CBot::CBotUserPointer::Create(obj));
+                        objVar->SetUserPointer(obj);
                         obj->GetBotVar()->SetPointer(objVar->GetPointer());
                     }
 

--- a/colobot-base/src/script/scriptfunc.cpp
+++ b/colobot-base/src/script/scriptfunc.cpp
@@ -376,7 +376,7 @@ bool CScriptFunctions::rIsBusy(CBotVar* var, CBotVar* result, int& exception, vo
 
     exception = 0;
 
-    CObject* obj = var->GetUserPointer()->GetPointerAs<CObject>();
+    CObject* obj = var->GetUserPointer().GetPointerAs<CObject>();
     if (obj == nullptr)
     {
         exception = ERR_WRONG_OBJ;
@@ -413,7 +413,7 @@ bool CScriptFunctions::rDestroy(CBotVar* var, CBotVar* result, int& exception, v
     if (var == nullptr)
         obj = CObjectManager::GetInstancePointer()->FindNearest(pThis, OBJECT_DESTROYER);
     else
-        obj = var->GetUserPointer()->GetPointerAs<CObject>();
+        obj = var->GetUserPointer().GetPointerAs<CObject>();
 
     if (obj == nullptr)
     {
@@ -498,7 +498,7 @@ bool CScriptFunctions::rFactory(CBotVar* var, CBotVar* result, int& exception, v
     if (var == nullptr)
         factory = CObjectManager::GetInstancePointer()->FindNearest(pThis, OBJECT_FACTORY);
     else
-        factory = var->GetUserPointer()->GetPointerAs<CObject>();
+        factory = var->GetUserPointer().GetPointerAs<CObject>();
 
     if (factory == nullptr)
     {
@@ -588,7 +588,7 @@ bool CScriptFunctions::rResearch(CBotVar* var, CBotVar* result, int& exception, 
     if (var == nullptr)
         center = CObjectManager::GetInstancePointer()->FindNearest(pThis, OBJECT_RESEARCH);
     else
-        center = var->GetUserPointer()->GetPointerAs<CObject>();
+        center = var->GetUserPointer().GetPointerAs<CObject>();
 
     if (center == nullptr)
     {
@@ -673,7 +673,7 @@ bool CScriptFunctions::rTakeOff(CBotVar* var, CBotVar* result, int& exception, v
     if (var == nullptr)
         base = CObjectManager::GetInstancePointer()->FindNearest(pThis, OBJECT_BASE);
     else
-        base = var->GetUserPointer()->GetPointerAs<CObject>();
+        base = var->GetUserPointer().GetPointerAs<CObject>();
 
     if (base == nullptr)
     {
@@ -3298,7 +3298,7 @@ bool CScriptFunctions::rCameraFocus(CBotVar* var, CBotVar* result, int& exceptio
     }
     else
     {
-        object = var->GetUserPointer()->GetPointerAs<CObject>();
+        object = var->GetUserPointer().GetPointerAs<CObject>();
         var = var->GetNext();
     }
     if (var != nullptr)
@@ -3848,18 +3848,14 @@ CBotVar* CScriptFunctions::CreateObjectVar(CObject* obj)
     pClass->SetUpdateFunc(CScriptFunctions::uObject);
 
     CBotVar* botVar = CBotVar::Create("", CBotTypResult(CBotTypClass, pClass));
-    botVar->SetUserPointer(CBotUserPointer::Create(obj));
+    botVar->SetUserPointer(obj);
     return botVar;
 }
 
 void CScriptFunctions::DestroyObjectVar(CBotVar* botVar, bool permanent)
 {
     if ( botVar == nullptr ) return;
-
-    if (const auto& user = botVar->GetUserPointer())
-    {
-        user->SetPointerAs(nullptr);
-    }
+    botVar->KillUserPointer();
     if (permanent)
         CBotVar::Destroy(botVar);
 }


### PR DESCRIPTION
I think this
```c++

        if (pItem->GetUserPointer().GetState() == PtrState::Dead)
        {
            pile->SetError(CBotErrDeletedPtr, prevToken);
            return pj->Return(pile);
        }
```
is easier to understand than this:
```c++
        if (const auto& userPtr = pItem->GetUserPointer())
        {
            if (userPtr->GetPointerAs<void>() == nullptr)
            {
                pile->SetError(CBotErrDeletedPtr, prevToken);
                return pj->Return(pile);
            }
        }
```



* Ref https://github.com/melex750/colobot/pull/2#discussion_r1902059131
* Ref https://github.com/melex750/colobot/pull/2#discussion_r1902059469
* Ref https://github.com/melex750/colobot/pull/2#discussion_r1902087689
* Ref https://github.com/melex750/colobot/pull/2#discussion_r1899933709