### PR TITLE
Simplify CBotVarArray

### DIFF
--- a/CBot/src/CBot/CBotVar/CBotVarArray.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarArray.cpp
@@ -73,16 +73,6 @@ void CBotVarArray::Copy(CBotVar* pSrc, bool bName)
 void CBotVarArray::SetPointer(const CBotVarSPtr& pVarClass)
 {
     m_binit = CBotVar::InitType::DEF;         // init, even on a null pointer
-
-    if ( m_pInstance == pVarClass) return;    // Special, not decrement and reincrement
-                                            // because the decrement can destroy the object
-
-    if ( pVarClass != nullptr )
-    {
-        if ( !pVarClass->m_type.Eq(CBotTypClass) &&
-             !pVarClass->m_type.Eq(CBotTypArrayBody))
-            assert(0);
-    }
     m_pInstance = pVarClass;
 }
 


### PR DESCRIPTION
Back when we had our own reference counters `CBotVarArray::SetPointer()` had special code to handle self-assignment, counter decrement and counter increment:

```c++
void CBotVarArray::SetPointer(CBotVar* pVarClass)
{
    m_binit = CBotVar::InitType::DEF;         // init, even on a null pointer

    if ( m_pInstance == pVarClass) return;    // Special, not decrement and reincrement
                                            // because the decrement can destroy the object

    if ( pVarClass != nullptr )
    {
        if ( pVarClass->GetType() == CBotTypArrayPointer )
             pVarClass = pVarClass->GetPointer();    // the real pointer to the object

        if ( !pVarClass->m_type.Eq(CBotTypClass) &&
             !pVarClass->m_type.Eq(CBotTypArrayBody))
            assert(0);

        (static_cast<CBotVarClass*>(pVarClass))->IncrementUse();            // increment the reference
    }

    if ( m_pInstance != nullptr ) m_pInstance->DecrementUse();
    m_pInstance = static_cast<CBotVarClass*>(pVarClass);
}
```
* https://github.com/melex750/colobot/pull/2 removes most of this code, but some leftovers remain:
```c++
void CBotVarArray::SetPointer(const CBotVarSPtr& pVarClass)
{
    m_binit = CBotVar::InitType::DEF;         // init, even on a null pointer

    if ( m_pInstance == pVarClass) return;    // Special, not decrement and reincrement
                                            // because the decrement can destroy the object

    if ( pVarClass != nullptr )
    {
        if ( !pVarClass->m_type.Eq(CBotTypClass) &&
             !pVarClass->m_type.Eq(CBotTypArrayBody))
            assert(0);
    }
    m_pInstance = pVarClass;
}
```
This leftovers appear to serve no useful purpose. Let's simplify this more:
```c++
void CBotVarArray::SetPointer(const CBotVarSPtr& pVarClass)
{
    m_binit = CBotVar::InitType::DEF;         // init, even on a null pointer
    m_pInstance = pVarClass;
}
```

Ref https://github.com/melex750/colobot/pull/2#discussion_r1902068565