### PR TITLE
Simplify CBotVarPointer::SetPointer

### DIFF
--- a/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
+++ b/CBot/src/CBot/CBotVar/CBotVarPointer.cpp
@@ -118,23 +118,19 @@ void CBotVarPointer::SetPointer(const CBotVarSPtr& pVarClass)
 {
     m_binit = CBotVar::InitType::DEF;                            // init, even on a null pointer
 
-    if ( m_pVarClass == pVarClass) return;    // special, not decrement and reincrement
-                                            // because the decrement can destroy the object
-
     if ( !pVarClass )
     {
         m_pVarClass.reset();
     }
     else
     {
-        auto instance = pVarClass; // the real pointer to the object
-        if (instance)
+        if (pVarClass)
         {
-            if (!instance->m_type.Eq(CBotTypClass)) assert(0);
-            m_pClass = (std::static_pointer_cast<CBotVarClass>(instance))->m_pClass;
+            assert(pVarClass->m_type.Eq(CBotTypClass));
+            m_pClass = (std::static_pointer_cast<CBotVarClass>(pVarClass))->m_pClass;
             m_type = CBotTypResult(CBotTypPointer, m_pClass);    // what kind of a pointer
         }
-        m_pVarClass = instance;
+        m_pVarClass = pVarClass;
     }
 }
 


### PR DESCRIPTION
Now that we use shared_ptr instead of our own reference counting I think we can simplify CBotVarPointer::SetPointer

Ref https://github.com/melex750/colobot/pull/2#discussion_r1902086203